### PR TITLE
Simplify midpoint computation in AbstractDiscreteDistribution.solveInverseCumulativeProbability

### DIFF
--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
@@ -121,15 +121,8 @@ abstract class AbstractDiscreteDistribution
                                                   int lower,
                                                   int upper) {
         while (lower + 1 < upper) {
-            int xm = (lower + upper) / 2;
-            if (xm < lower || xm > upper) {
-                /*
-                 * Overflow.
-                 * There will never be an overflow in both calculation methods
-                 * for xm at the same time
-                 */
-                xm = lower + (upper - lower) / 2;
-            }
+            // Overflow-aware midpoint computation
+            int xm = (lower + upper) >>> 1;
 
             double pm = checkedCumulativeProbability(xm);
             if (pm >= p) {

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
@@ -120,11 +120,16 @@ abstract class AbstractDiscreteDistribution
     private int solveInverseCumulativeProbability(final double p,
                                                   int lower,
                                                   int upper) {
+        // Using long variables instead of int to avoid overflow when computing
+        // xm inside the loop.
         long l = lower;
         long u = upper;
         while (l + 1 < u) {
-            // Replaced division by two with shift
-            long xm = (l + u) >>> 1;
+            // Cannot replace division by 2 with a right shift because (l + u)
+            // can be negative. This can be optimized when we know that both
+            // lower and upper arguments of this method are positive, for
+            // example, for PoissonDistribution.
+            long xm = (l + u) / 2;
             double pm = checkedCumulativeProbability((int) xm);
             if (pm >= p) {
                 u = xm;

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
@@ -120,18 +120,19 @@ abstract class AbstractDiscreteDistribution
     private int solveInverseCumulativeProbability(final double p,
                                                   int lower,
                                                   int upper) {
-        while (lower + 1 < upper) {
-            // Overflow-aware midpoint computation
-            int xm = (lower + upper) >>> 1;
-
-            double pm = checkedCumulativeProbability(xm);
+        long l = lower;
+        long u = upper;
+        while (l + 1 < u) {
+            // Replaced division by two with shift
+            long xm = (l + u) >>> 1;
+            double pm = checkedCumulativeProbability((int) xm);
             if (pm >= p) {
-                upper = xm;
+                u = xm;
             } else {
-                lower = xm;
+                l = xm;
             }
         }
-        return upper;
+        return (int) u;
     }
 
     /**


### PR DESCRIPTION
Avoiding a cumbersome branch inside the loop in `AbstractDiscreteDistribution.solveInverseCumulativeProbability()` by using `long` variables.