### PR TITLE
Update PMD since the current rules are deprecated.

### DIFF
--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistribution.java
@@ -18,7 +18,6 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.distribution.InverseTransformDiscreteSampler;
-import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
 
 /**
  * Base class for integer-valued discrete distributions.  Default
@@ -62,7 +61,7 @@ abstract class AbstractDiscreteDistribution
         }
 
         int lower = getSupportLowerBound();
-        if (p == 0.0) {
+        if (p == 0) {
             return lower;
         }
         if (lower == Integer.MIN_VALUE) {
@@ -75,7 +74,7 @@ abstract class AbstractDiscreteDistribution
         }
 
         int upper = getSupportUpperBound();
-        if (p == 1.0) {
+        if (p == 1) {
             return upper;
         }
 
@@ -112,13 +111,15 @@ abstract class AbstractDiscreteDistribution
      * smallest {@code p}-quantile {@code inf{x in Z | P(X <= x) >= p}}.
      *
      * @param p Cumulative probability.
-     * @param lower Value satisfying {@code cumulativeProbability(lower) < p}.
-     * @param upper Value satisfying {@code p <= cumulativeProbability(upper)}.
+     * @param lowerBound Value satisfying {@code cumulativeProbability(lower) < p}.
+     * @param upperBound Value satisfying {@code p <= cumulativeProbability(upper)}.
      * @return the smallest {@code p}-quantile of this distribution.
      */
     private int solveInverseCumulativeProbability(final double p,
-                                                  int lower,
-                                                  int upper) {
+                                                  int lowerBound,
+                                                  int upperBound) {
+        int lower = lowerBound;
+        int upper = upperBound;
         while (lower + 1 < upper) {
             int xm = (lower + upper) / 2;
             if (xm < lower || xm > upper) {
@@ -130,7 +131,7 @@ abstract class AbstractDiscreteDistribution
                 xm = lower + (upper - lower) / 2;
             }
 
-            double pm = checkedCumulativeProbability(xm);
+            final double pm = checkedCumulativeProbability(xm);
             if (pm >= p) {
                 upper = xm;
             } else {
@@ -180,8 +181,6 @@ abstract class AbstractDiscreteDistribution
     @Override
     public DiscreteDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Inversion method distribution sampler.
-        final DiscreteSampler sampler =
-            new InverseTransformDiscreteSampler(rng, this::inverseCumulativeProbability);
-        return sampler::sample;
+        return new InverseTransformDiscreteSampler(rng, this::inverseCumulativeProbability)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BetaDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BetaDistribution.java
@@ -19,7 +19,6 @@ package org.apache.commons.statistics.distribution;
 import org.apache.commons.numbers.gamma.RegularizedBeta;
 import org.apache.commons.numbers.gamma.LogGamma;
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.ChengBetaSampler;
 
 /**
@@ -90,8 +89,8 @@ public class BetaDistribution extends AbstractContinuousDistribution {
             }
             return Double.NEGATIVE_INFINITY;
         } else {
-            double logX = Math.log(x);
-            double log1mX = Math.log1p(-x);
+            final double logX = Math.log(x);
+            final double log1mX = Math.log1p(-x);
             return (alpha - 1) * logX + (beta - 1) * log1mX - z;
         }
     }
@@ -186,7 +185,6 @@ public class BetaDistribution extends AbstractContinuousDistribution {
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Beta distribution sampler.
-        final ContinuousSampler sampler = new ChengBetaSampler(rng, alpha, beta);
-        return sampler::sample;
+        return new ChengBetaSampler(rng, alpha, beta)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BinomialDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BinomialDistribution.java
@@ -85,7 +85,7 @@ public class BinomialDistribution extends AbstractDiscreteDistribution {
         if (x < 0 || x > numberOfTrials) {
             ret = Double.NEGATIVE_INFINITY;
         } else {
-            ret = SaddlePointExpansion.logBinomialProbability(x,
+            ret = SaddlePointExpansionUtils.logBinomialProbability(x,
                     numberOfTrials, probabilityOfSuccess,
                     1.0 - probabilityOfSuccess);
         }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/DistributionException.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/DistributionException.java
@@ -23,23 +23,23 @@ import java.text.MessageFormat;
  */
 class DistributionException extends IllegalArgumentException {
     /** Error message for "too large" condition. */
-    /* default */ static final String TOO_LARGE = "{0} > {1}";
+    static final String TOO_LARGE = "{0} > {1}";
     /** Error message for "too small" condition. */
-    /* default */ static final String TOO_SMALL = "{0} < {1}";
+    static final String TOO_SMALL = "{0} < {1}";
     /** Error message for "out of range" condition. */
-    /* default */ static final String OUT_OF_RANGE = "Number {0} is out of range [{1}, {2}]";
+    static final String OUT_OF_RANGE = "Number {0} is out of range [{1}, {2}]";
     /** Error message for "out of range" condition. */
-    /* default */ static final String NEGATIVE = "Number {0} is negative";
+    static final String NEGATIVE = "Number {0} is negative";
     /** Error message for "mismatch" condition. */
-    /* default */ static final String MISMATCH = "Expected {1} but was {0}";
+    static final String MISMATCH = "Expected {1} but was {0}";
     /** Error message for "failed bracketing" condition. */
-    /* default */ static final String BRACKETING = "No bracketing: f({0})={1}, f({2})={3}";
+    static final String BRACKETING = "No bracketing: f({0})={1}, f({2})={3}";
 
     /** Serializable version identifier. */
     private static final long serialVersionUID = 20180119L;
 
     /** Arguments for formatting the message. */
-    private Object[] formatArguments;
+    private final Object[] formatArguments;
 
     /**
      * Create an exception where the message is constructed by applying

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ExponentialDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ExponentialDistribution.java
@@ -17,7 +17,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.AhrensDieterExponentialSampler;
 
 /**
@@ -167,7 +166,6 @@ public class ExponentialDistribution extends AbstractContinuousDistribution {
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Exponential distribution sampler.
-        final ContinuousSampler sampler = new AhrensDieterExponentialSampler(rng, mean);
-        return sampler::sample;
+        return new AhrensDieterExponentialSampler(rng, mean)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/FDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/FDistribution.java
@@ -27,6 +27,11 @@ import org.apache.commons.numbers.gamma.RegularizedBeta;
  * @see <a href="http://mathworld.wolfram.com/F-Distribution.html">F-distribution (MathWorld)</a>
  */
 public class FDistribution extends AbstractContinuousDistribution {
+    /** The minimum degrees of freedom for the denominator when computing the mean. */
+    private static final double MIN_DENOMINATOR_DF_FOR_MEAN = 2.0;
+    /** The minimum degrees of freedom for the denominator when computing the variance. */
+    private static final double MIN_DENOMINATOR_DF_FOR_VARIANCE = 4.0;
+
     /** The numerator degrees of freedom. */
     private final double numeratorDegreesOfFreedom;
     /** The numerator degrees of freedom. */
@@ -94,8 +99,8 @@ public class FDistribution extends AbstractContinuousDistribution {
         if (x <= 0) {
             ret = 0;
         } else {
-            double n = numeratorDegreesOfFreedom;
-            double m = denominatorDegreesOfFreedom;
+            final double n = numeratorDegreesOfFreedom;
+            final double m = denominatorDegreesOfFreedom;
 
             ret = RegularizedBeta.value((n * x) / (m + n * x),
                 0.5 * n,
@@ -135,7 +140,7 @@ public class FDistribution extends AbstractContinuousDistribution {
     public double getMean() {
         final double denominatorDF = getDenominatorDegreesOfFreedom();
 
-        if (denominatorDF > 2) {
+        if (denominatorDF > MIN_DENOMINATOR_DF_FOR_MEAN) {
             return denominatorDF / (denominatorDF - 2);
         }
 
@@ -159,7 +164,7 @@ public class FDistribution extends AbstractContinuousDistribution {
     public double getVariance() {
         final double denominatorDF = getDenominatorDegreesOfFreedom();
 
-        if (denominatorDF > 4) {
+        if (denominatorDF > MIN_DENOMINATOR_DF_FOR_VARIANCE) {
             final double numeratorDF = getNumeratorDegreesOfFreedom();
             final double denomDFMinusTwo = denominatorDF - 2;
 

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GammaDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GammaDistribution.java
@@ -19,7 +19,6 @@ package org.apache.commons.statistics.distribution;
 import org.apache.commons.numbers.gamma.LanczosApproximation;
 import org.apache.commons.numbers.gamma.RegularizedGamma;
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.AhrensDieterMarsagliaTsangGammaSampler;
 
 /**
@@ -338,8 +337,6 @@ public class GammaDistribution extends AbstractContinuousDistribution {
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Gamma distribution sampler.
-        final ContinuousSampler sampler =
-            new AhrensDieterMarsagliaTsangGammaSampler(rng, scale, shape);
-        return sampler::sample;
+        return new AhrensDieterMarsagliaTsangGammaSampler(rng, scale, shape)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/HypergeometricDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/HypergeometricDistribution.java
@@ -73,7 +73,7 @@ public class HypergeometricDistribution extends AbstractDiscreteDistribution {
     public double cumulativeProbability(int x) {
         double ret;
 
-        int[] domain = getDomain(populationSize, numberOfSuccesses, sampleSize);
+        final int[] domain = getDomain(populationSize, numberOfSuccesses, sampleSize);
         if (x < domain[0]) {
             ret = 0.0;
         } else if (x >= domain[1]) {
@@ -162,18 +162,18 @@ public class HypergeometricDistribution extends AbstractDiscreteDistribution {
     public double logProbability(int x) {
         double ret;
 
-        int[] domain = getDomain(populationSize, numberOfSuccesses, sampleSize);
+        final int[] domain = getDomain(populationSize, numberOfSuccesses, sampleSize);
         if (x < domain[0] || x > domain[1]) {
             ret = Double.NEGATIVE_INFINITY;
         } else {
-            double p = (double) sampleSize / (double) populationSize;
-            double q = (double) (populationSize - sampleSize) / (double) populationSize;
-            double p1 = SaddlePointExpansion.logBinomialProbability(x,
+            final double p = (double) sampleSize / (double) populationSize;
+            final double q = (double) (populationSize - sampleSize) / (double) populationSize;
+            final double p1 = SaddlePointExpansion.logBinomialProbability(x,
                     numberOfSuccesses, p, q);
-            double p2 =
+            final double p2 =
                     SaddlePointExpansion.logBinomialProbability(sampleSize - x,
                             populationSize - numberOfSuccesses, p, q);
-            double p3 =
+            final double p3 =
                     SaddlePointExpansion.logBinomialProbability(sampleSize, populationSize, p, q);
             ret = p1 + p2 - p3;
         }
@@ -217,10 +217,11 @@ public class HypergeometricDistribution extends AbstractDiscreteDistribution {
      * @return {@code P(x0 <= X <= x1)}.
      */
     private double innerCumulativeProbability(int x0, int x1, int dx) {
-        double ret = probability(x0);
-        while (x0 != x1) {
-            x0 += dx;
-            ret += probability(x0);
+        int x = x0;
+        double ret = probability(x);
+        while (x != x1) {
+            x += dx;
+            ret += probability(x);
         }
         return ret;
     }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/HypergeometricDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/HypergeometricDistribution.java
@@ -168,13 +168,13 @@ public class HypergeometricDistribution extends AbstractDiscreteDistribution {
         } else {
             final double p = (double) sampleSize / (double) populationSize;
             final double q = (double) (populationSize - sampleSize) / (double) populationSize;
-            final double p1 = SaddlePointExpansion.logBinomialProbability(x,
+            final double p1 = SaddlePointExpansionUtils.logBinomialProbability(x,
                     numberOfSuccesses, p, q);
             final double p2 =
-                    SaddlePointExpansion.logBinomialProbability(sampleSize - x,
+                    SaddlePointExpansionUtils.logBinomialProbability(sampleSize - x,
                             populationSize - numberOfSuccesses, p, q);
             final double p3 =
-                    SaddlePointExpansion.logBinomialProbability(sampleSize, populationSize, p, q);
+                    SaddlePointExpansionUtils.logBinomialProbability(sampleSize, populationSize, p, q);
             ret = p1 + p2 - p3;
         }
 

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LaplaceDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LaplaceDistribution.java
@@ -42,7 +42,7 @@ public class LaplaceDistribution extends AbstractContinuousDistribution {
      */
     public LaplaceDistribution(double mu,
                                double beta) {
-        if (beta <= 0.0) {
+        if (beta <= 0) {
             throw new DistributionException(DistributionException.NEGATIVE, beta);
         }
 
@@ -95,7 +95,7 @@ public class LaplaceDistribution extends AbstractContinuousDistribution {
         } else if (p == 1) {
             return Double.POSITIVE_INFINITY;
         }
-        double x = (p > 0.5) ? -Math.log(2.0 - 2.0 * p) : Math.log(2.0 * p);
+        final double x = (p > 0.5) ? -Math.log(2.0 - 2.0 * p) : Math.log(2.0 * p);
         return mu + beta * x;
     }
 
@@ -128,5 +128,4 @@ public class LaplaceDistribution extends AbstractContinuousDistribution {
     public boolean isSupportConnected() {
         return true;
     }
-
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LogNormalDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LogNormalDistribution.java
@@ -20,7 +20,6 @@ package org.apache.commons.statistics.distribution;
 import org.apache.commons.numbers.gamma.Erf;
 import org.apache.commons.numbers.gamma.ErfDifference;
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.LogNormalSampler;
 import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSampler;
 
@@ -180,7 +179,7 @@ public class LogNormalDistribution extends AbstractContinuousDistribution {
      */
     @Override
     public double getMean() {
-        double s = shape;
+        final double s = shape;
         return Math.exp(scale + (s * s / 2));
     }
 
@@ -239,8 +238,6 @@ public class LogNormalDistribution extends AbstractContinuousDistribution {
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Log normal distribution sampler.
-        final ContinuousSampler sampler =
-            new LogNormalSampler(new ZigguratNormalizedGaussianSampler(rng), scale, shape);
-        return sampler::sample;
+        return new LogNormalSampler(new ZigguratNormalizedGaussianSampler(rng), scale, shape)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NakagamiDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NakagamiDistribution.java
@@ -23,6 +23,9 @@ import org.apache.commons.numbers.gamma.RegularizedGamma;
  * This class implements the <a href="http://en.wikipedia.org/wiki/Nakagami_distribution">Nakagami distribution</a>.
  */
 public class NakagamiDistribution extends AbstractContinuousDistribution {
+    /** The minimum allowed for the shape parameter. */
+    private static final double MIN_SHAPE = 0.5;
+
     /** The shape parameter. */
     private final double mu;
     /** The scale parameter. */
@@ -38,8 +41,8 @@ public class NakagamiDistribution extends AbstractContinuousDistribution {
      */
     public NakagamiDistribution(double mu,
                                 double omega) {
-        if (mu < 0.5) {
-            throw new DistributionException(DistributionException.TOO_SMALL, mu, 0.5);
+        if (mu < MIN_SHAPE) {
+            throw new DistributionException(DistributionException.TOO_SMALL, mu, MIN_SHAPE);
         }
         if (omega <= 0) {
             throw new DistributionException(DistributionException.NEGATIVE, omega);
@@ -92,7 +95,7 @@ public class NakagamiDistribution extends AbstractContinuousDistribution {
     /** {@inheritDoc} */
     @Override
     public double getVariance() {
-        double v = Gamma.value(mu + 0.5) / Gamma.value(mu);
+        final double v = Gamma.value(mu + 0.5) / Gamma.value(mu);
         return omega * (1 - 1 / mu * v * v);
     }
 

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NormalDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NormalDistribution.java
@@ -21,7 +21,6 @@ import org.apache.commons.numbers.gamma.Erfc;
 import org.apache.commons.numbers.gamma.InverseErf;
 import org.apache.commons.numbers.gamma.ErfDifference;
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.GaussianSampler;
 import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSampler;
 
@@ -180,9 +179,7 @@ public class NormalDistribution extends AbstractContinuousDistribution {
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Gaussian distribution sampler.
-        final ContinuousSampler sampler =
-            new GaussianSampler(new ZigguratNormalizedGaussianSampler(rng),
-                                mean, standardDeviation);
-        return sampler::sample;
+        return new GaussianSampler(new ZigguratNormalizedGaussianSampler(rng),
+                                   mean, standardDeviation)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ParetoDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ParetoDistribution.java
@@ -18,7 +18,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.InverseTransformParetoSampler;
 
 /**
@@ -36,6 +35,9 @@ import org.apache.commons.rng.sampling.distribution.InverseTransformParetoSample
  * </ul>
  */
 public class ParetoDistribution extends AbstractContinuousDistribution {
+    /** The minimum value for the shape parameter when computing when computing the variance. */
+    private static final double MIN_SHAPE_FOR_VARIANCE = 2.0;
+
     /** The scale parameter of this distribution. */
     private final double scale;
     /** The shape parameter of this distribution. */
@@ -155,10 +157,10 @@ public class ParetoDistribution extends AbstractContinuousDistribution {
      */
     @Override
     public double getVariance() {
-        if (shape <= 2) {
+        if (shape <= MIN_SHAPE_FOR_VARIANCE) {
             return Double.POSITIVE_INFINITY;
         }
-        double s = shape - 1;
+        final double s = shape - 1;
         return scale * scale * shape / (s * s) / (shape - 2);
     }
 
@@ -202,7 +204,6 @@ public class ParetoDistribution extends AbstractContinuousDistribution {
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Pareto distribution sampler.
-        final ContinuousSampler sampler = new InverseTransformParetoSampler(rng, scale, shape);
-        return sampler::sample;
+        return new InverseTransformParetoSampler(rng, scale, shape)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PoissonDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PoissonDistribution.java
@@ -18,7 +18,6 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.gamma.RegularizedGamma;
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
 import org.apache.commons.rng.sampling.distribution.PoissonSampler;
 
 /**
@@ -184,7 +183,6 @@ public class PoissonDistribution extends AbstractDiscreteDistribution {
     @Override
     public DiscreteDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Poisson distribution sampler.
-        final DiscreteSampler sampler = new PoissonSampler(rng, mean);
-        return sampler::sample;
+        return new PoissonSampler(rng, mean)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PoissonDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PoissonDistribution.java
@@ -88,8 +88,8 @@ public class PoissonDistribution extends AbstractDiscreteDistribution {
         } else if (x == 0) {
             ret = -mean;
         } else {
-            ret = -SaddlePointExpansion.getStirlingError(x) -
-                  SaddlePointExpansion.getDeviancePart(x, mean) -
+            ret = -SaddlePointExpansionUtils.getStirlingError(x) -
+                  SaddlePointExpansionUtils.getDeviancePart(x, mean) -
                   0.5 * LOG_TWO_PI - 0.5 * Math.log(x);
         }
         return ret;

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/SaddlePointExpansion.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/SaddlePointExpansion.java
@@ -28,13 +28,17 @@ import org.apache.commons.numbers.gamma.LogGamma;
  *
  * @since 1.0
  */
-/* default */ final class SaddlePointExpansion {
+final class SaddlePointExpansion {
     /** 2 &pi;. */
     private static final double TWO_PI = 2 * Math.PI;
     /** 1/2 * log(2 &pi;). */
     private static final double HALF_LOG_TWO_PI = 0.5 * Math.log(TWO_PI);
+    /** 1/10. */
+    private static final double ONE_TENTH = 0.1;
+    /** The threshold value for switching the method to compute th Stirling error. */
+    private static final double STIRLING_ERROR_THRESHOLD = 15.0;
 
-    /** exact Stirling expansion error for certain values. */
+    /** Exact Stirling expansion error for certain values. */
     private static final double[] EXACT_STIRLING_ERRORS = {
         0.0, /* 0.0 */
         0.1534264097200273452913848, /* 0.5 */
@@ -89,10 +93,10 @@ import org.apache.commons.numbers.gamma.LogGamma;
      * @param z the value.
      * @return the Striling's series error.
      */
-    /* default */ static double getStirlingError(double z) {
+    static double getStirlingError(double z) {
         double ret;
-        if (z < 15.0) {
-            double z2 = 2.0 * z;
+        if (z < STIRLING_ERROR_THRESHOLD) {
+            final double z2 = 2.0 * z;
             if (Math.floor(z2) == z2) {
                 ret = EXACT_STIRLING_ERRORS[(int) z2];
             } else {
@@ -100,7 +104,7 @@ import org.apache.commons.numbers.gamma.LogGamma;
                       z - HALF_LOG_TWO_PI;
             }
         } else {
-            double z2 = z * z;
+            final double z2 = z * z;
             ret = (0.083333333333333333333 -
                     (0.00277777777777777777778 -
                             (0.00079365079365079365079365 -
@@ -127,10 +131,10 @@ import org.apache.commons.numbers.gamma.LogGamma;
      * @param mu the average.
      * @return a part of the deviance.
      */
-    /* default */ static double getDeviancePart(double x, double mu) {
+    static double getDeviancePart(double x, double mu) {
         double ret;
         if (Math.abs(x - mu) < 0.1 * (x + mu)) {
-            double d = x - mu;
+            final double d = x - mu;
             double v = d / (x + mu);
             double s1 = v * d;
             double s = Double.NaN;
@@ -163,10 +167,10 @@ import org.apache.commons.numbers.gamma.LogGamma;
      * @param q the probability of failure (1 - p).
      * @return log(p(x)).
      */
-    /* default */ static double logBinomialProbability(int x, int n, double p, double q) {
+    static double logBinomialProbability(int x, int n, double p, double q) {
         double ret;
         if (x == 0) {
-            if (p < 0.1) {
+            if (p < ONE_TENTH) {
                 ret = -getDeviancePart(n, n * q) - n * p;
             } else {
                 if (n == 0) {
@@ -175,7 +179,7 @@ import org.apache.commons.numbers.gamma.LogGamma;
                 ret = n * Math.log(q);
             }
         } else if (x == n) {
-            if (q < 0.1) {
+            if (q < ONE_TENTH) {
                 ret = -getDeviancePart(n, n * p) - n * q;
             } else {
                 ret = n * Math.log(p);

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/SaddlePointExpansionUtils.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/SaddlePointExpansionUtils.java
@@ -28,7 +28,7 @@ import org.apache.commons.numbers.gamma.LogGamma;
  *
  * @since 1.0
  */
-final class SaddlePointExpansion {
+final class SaddlePointExpansionUtils {
     /** 2 &pi;. */
     private static final double TWO_PI = 2 * Math.PI;
     /** 1/2 * log(2 &pi;). */
@@ -76,7 +76,7 @@ final class SaddlePointExpansion {
     /**
      * Forbid construction.
      */
-    private SaddlePointExpansion() {}
+    private SaddlePointExpansionUtils() {}
 
     /**
      * Compute the error of Stirling's series at the given value.

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/TriangularDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/TriangularDistribution.java
@@ -92,16 +92,16 @@ public class TriangularDistribution extends AbstractContinuousDistribution {
             return 0;
         }
         if (a <= x && x < c) {
-            double divident = 2 * (x - a);
-            double divisor = (b - a) * (c - a);
+            final double divident = 2 * (x - a);
+            final double divisor = (b - a) * (c - a);
             return divident / divisor;
         }
         if (x == c) {
             return 2 / (b - a);
         }
         if (c < x && x <= b) {
-            double divident = 2 * (b - x);
-            double divisor = (b - a) * (b - c);
+            final double divident = 2 * (b - x);
+            final double divisor = (b - a) * (b - c);
             return divident / divisor;
         }
         return 0;
@@ -126,16 +126,16 @@ public class TriangularDistribution extends AbstractContinuousDistribution {
             return 0;
         }
         if (a <= x && x < c) {
-            double divident = (x - a) * (x - a);
-            double divisor = (b - a) * (c - a);
+            final double divident = (x - a) * (x - a);
+            final double divisor = (b - a) * (c - a);
             return divident / divisor;
         }
         if (x == c) {
             return (c - a) / (b - a);
         }
         if (c < x && x <= b) {
-            double divident = (b - x) * (b - x);
-            double divisor = (b - a) * (b - c);
+            final double divident = (b - x) * (b - x);
+            final double divisor = (b - a) * (b - c);
             return 1 - (divident / divisor);
         }
         return 1;

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/UniformContinuousDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/UniformContinuousDistribution.java
@@ -18,7 +18,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.ContinuousUniformSampler;
 
 /**
@@ -99,7 +98,7 @@ public class UniformContinuousDistribution extends AbstractContinuousDistributio
      */
     @Override
     public double getVariance() {
-        double ul = upper - lower;
+        final double ul = upper - lower;
         return ul * ul / 12;
     }
 
@@ -145,7 +144,6 @@ public class UniformContinuousDistribution extends AbstractContinuousDistributio
     @Override
     public ContinuousDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Uniform distribution sampler.
-        final ContinuousSampler sampler = new ContinuousUniformSampler(rng, lower, upper);
-        return sampler::sample;
+        return new ContinuousUniformSampler(rng, lower, upper)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/UniformDiscreteDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/UniformDiscreteDistribution.java
@@ -18,7 +18,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
 import org.apache.commons.rng.sampling.distribution.DiscreteUniformSampler;
 
 /**
@@ -97,7 +96,7 @@ public class UniformDiscreteDistribution extends AbstractDiscreteDistribution {
      */
     @Override
     public double getVariance() {
-        double n = upperMinusLower + 1;
+        final double n = upperMinusLower + 1;
         return ONE_TWELFTH * (n * n - 1);
     }
 
@@ -143,7 +142,6 @@ public class UniformDiscreteDistribution extends AbstractDiscreteDistribution {
     @Override
     public DiscreteDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Discrete uniform distribution sampler.
-        final DiscreteSampler sampler = new DiscreteUniformSampler(rng, lower, upper);
-        return sampler::sample;
+        return new DiscreteUniformSampler(rng, lower, upper)::sample;
     }
 }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/WeibullDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/WeibullDistribution.java
@@ -119,7 +119,7 @@ public class WeibullDistribution extends AbstractContinuousDistribution {
     @Override
     public double cumulativeProbability(double x) {
         double ret;
-        if (x <= 0.0) {
+        if (x <= 0) {
             ret = 0.0;
         } else {
             ret = 1.0 - Math.exp(-Math.pow(x / scale, shape));

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ZipfDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ZipfDistribution.java
@@ -18,7 +18,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
 import org.apache.commons.rng.sampling.distribution.RejectionInversionZipfSampler;
 
 /**
@@ -220,8 +219,6 @@ public class ZipfDistribution extends AbstractDiscreteDistribution {
     @Override
     public DiscreteDistribution.Sampler createSampler(final UniformRandomProvider rng) {
         // Zipf distribution sampler.
-        final DiscreteSampler sampler =
-            new RejectionInversionZipfSampler(rng, numberOfElements, exponent);
-        return sampler::sample;
+        return new RejectionInversionZipfSampler(rng, numberOfElements, exponent)::sample;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,8 @@
     <commons.encoding>UTF-8</commons.encoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <statistics.pmd.version>3.8</statistics.pmd.version>
+    <statistics.pmd.version>3.12.0</statistics.pmd.version>
+    <statistics.pmd.dep.version>6.14.0</statistics.pmd.dep.version>
     <statistics.spotbugs.version>3.1.11</statistics.spotbugs.version>
     <statistics.checkstyle.version>3.0.0</statistics.checkstyle.version>
     <statistics.checkstyle.dep.version>8.20</statistics.checkstyle.dep.version>
@@ -259,6 +260,18 @@
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>${statistics.pmd.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-core</artifactId>
+            <version>${statistics.pmd.dep.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-java</artifactId>
+            <version>${statistics.pmd.dep.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <targetJdk>${maven.compiler.target}</targetJdk>
           <skipEmptyReport>false</skipEmptyReport>
@@ -382,6 +395,7 @@
         <configuration>
           <targetJdk>${maven.compiler.target}</targetJdk>
           <skipEmptyReport>false</skipEmptyReport>
+          <analysisCache>true</analysisCache>
           <rulesets>
             <ruleset>${statistics.parent.dir}/src/main/resources/pmd/pmd-ruleset.xml</ruleset>
           </rulesets>

--- a/src/main/resources/pmd/pmd-ruleset.xml
+++ b/src/main/resources/pmd/pmd-ruleset.xml
@@ -77,14 +77,6 @@
     </properties>
   </rule>
 
-  <rule ref="category/java/codestyle.xml/ClassNamingConventions">
-    <properties>
-      <!-- Do not require Utils/Helper suffix. -->
-      <property name="violationSuppressXPath"
-        value="//ClassOrInterfaceDeclaration[@Image='SaddlePointExpansion']"/>
-    </properties>
-  </rule>
-
   <rule ref="category/java/documentation.xml/CommentSize">
     <properties>
       <property name="maxLines"      value="200"/>

--- a/src/main/resources/pmd/pmd-ruleset.xml
+++ b/src/main/resources/pmd/pmd-ruleset.xml
@@ -23,35 +23,93 @@
     This ruleset checks the code for discouraged programming constructs.
   </description>
 
-  <rule ref="rulesets/java/basic.xml"/>
-
-  <rule ref="rulesets/java/braces.xml"/>
-
-  <rule ref="rulesets/java/comments.xml">
-    <exclude name="CommentSize"/>
+  <rule ref="category/java/bestpractices.xml">
+    <exclude name="UseVarargs" />
   </rule>
-  <rule ref="rulesets/java/comments.xml/CommentSize">
+  <rule ref="category/java/codestyle.xml">
+    <exclude name="MethodArgumentCouldBeFinal" />
+    <exclude name="ShortVariable" />
+    <exclude name="LongVariable" />
+    <exclude name="CommentDefaultAccessModifier" />
+    <exclude name="DefaultPackage" />
+    <exclude name="CallSuperInConstructor" />
+    <exclude name="AbstractNaming" />
+    <!-- We do use extra parentheses there as most people do not recall operator precedence,
+         this means even if the parentheses are useless for the compiler, we don't consider
+         them useless for the developer. This is the reason why we disable this rule. -->
+    <exclude name="UselessParentheses" />
+    <exclude name="AtLeastOneConstructor" />
+    <exclude name="GenericsNaming" />
+    <exclude name="OnlyOneReturn" />
+    <exclude name="UseUnderscoresInNumericLiterals" />
+
+    <!-- Disable this rule in favour of the more configurable rule in checkstyle. -->
+    <exclude name="LocalVariableNamingConventions" />
+  </rule>
+  <rule ref="category/java/design.xml">
+    <exclude name="TooManyMethods" />
+    <exclude name="LawOfDemeter" />
+    <exclude name="NcssCount" />
+    <exclude name="LoosePackageCoupling" />
+  </rule>
+  <rule ref="category/java/documentation.xml">
+    <exclude name="CommentSize" />
+  </rule>
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="BeanMembersShouldSerialize" />
+    <!-- This rule is known to be poor with Java 5 and later:
+      https://github.com/pmd/pmd/issues/873 -->
+    <exclude name="DataflowAnomalyAnalysis" />
+  </rule>
+  <rule ref="category/java/multithreading.xml">
+    <!-- <exclude name="..." /> -->
+  </rule>
+  <rule ref="category/java/performance.xml">
+    <!-- <exclude name="..." /> -->
+  </rule>
+
+  <!-- Rule customisations. -->
+
+  <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly">
+    <properties>
+      <!-- Array is generated internally in this case. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='DistributionException']"/>
+    </properties>
+  </rule>
+
+  <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+    <properties>
+      <!-- Do not require Utils/Helper suffix. -->
+      <property name="violationSuppressXPath"
+        value="//ClassOrInterfaceDeclaration[@Image='SaddlePointExpansion']"/>
+    </properties>
+  </rule>
+
+  <rule ref="category/java/documentation.xml/CommentSize">
     <properties>
       <property name="maxLines"      value="200"/>
       <property name="maxLineLength" value="256"/>
     </properties>
   </rule>
 
-  <rule ref="rulesets/java/empty.xml"/>
+  <rule ref="category/java/design.xml/NPathComplexity">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//ClassOrInterfaceDeclaration[@Image='AbstractContinuousDistribution']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/CyclomaticComplexity">
+    <properties>
+      <!-- Increase from default of 10. -->
+      <property name="methodReportLevel" value="20"/>
+    </properties>
+  </rule>
 
-  <rule ref="rulesets/java/finalizers.xml"/>
-
-  <rule ref="rulesets/java/imports.xml"/>
-
-  <rule ref="rulesets/java/typeresolution.xml"/>
-
-  <rule ref="rulesets/java/clone.xml"/>
-
-  <rule ref="rulesets/java/unnecessary.xml">
-    <!-- We do use extra parentheses there as most people do not recall operator precedence,
-         this means even if the parentheses are useless for the compiler, we don't consider
-         them useless for the developer. This is the reason why we disable this rule. -->
-    <exclude name="UselessParentheses"/>
+  <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition">
+    <properties>
+      <!-- Add 1 as a magic number. -->
+      <property name="ignoreMagicNumbers" value="-1,0,1" />
+    </properties>
   </rule>
 
 </ruleset>

--- a/src/main/resources/spotbugs/spotbugs-exclude-filter.xml
+++ b/src/main/resources/spotbugs/spotbugs-exclude-filter.xml
@@ -31,7 +31,7 @@
   </Match>
 
   <Match>
-    <Class name="org.apache.commons.statistics.distribution.SaddlePointExpansion" />
+    <Class name="org.apache.commons.statistics.distribution.SaddlePointExpansionUtils" />
     <Or>
       <Method name="getStirlingError" />
       <Method name="getDeviancePart" />


### PR DESCRIPTION
Fix code to:
- Use final local variables
- Return sampler method references directly
- Removed use of /* default */ for package-private
- Avoid reassigning parameters
- Avoid literals in conditional statements
- Compact code to avoid long methods (>100 lines)