### PR TITLE
Upgrade junit5

### DIFF
--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractContinuousDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractContinuousDistributionTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.analysis.integration.RombergIntegrator;
 import org.apache.commons.math3.analysis.integration.UnivariateIntegrator;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Various tests related to MATH-699. */
 public class AbstractContinuousDistributionTest {

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractContinuousDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractContinuousDistributionTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.statistics.distribution;
 import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.analysis.integration.RombergIntegrator;
 import org.apache.commons.math3.analysis.integration.UnivariateIntegrator;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Various tests related to MATH-699. */
@@ -104,7 +104,7 @@ public class AbstractContinuousDistributionTest {
         };
         final double expected = x1;
         final double actual = distribution.inverseCumulativeProbability(p12);
-        Assert.assertEquals("", expected, actual, 1e-8);
+        Assertions.assertEquals(expected, actual, 1e-8);
     }
 
     @Test
@@ -203,6 +203,6 @@ public class AbstractContinuousDistributionTest {
         };
         final double expected = x2;
         final double actual = distribution.inverseCumulativeProbability(p23);
-        Assert.assertEquals("", expected, actual, 1e-8);
+        Assertions.assertEquals(expected, actual, 1e-8);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistributionTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,30 +30,30 @@ public class AbstractDiscreteDistributionTest {
     @Test
     public void testInverseCumulativeProbabilityMethod() {
         double precision = 0.000000000000001;
-        Assert.assertEquals(1, diceDistribution.inverseCumulativeProbability(0));
-        Assert.assertEquals(1, diceDistribution.inverseCumulativeProbability((1d - Double.MIN_VALUE) / 6d));
-        Assert.assertEquals(2, diceDistribution.inverseCumulativeProbability((1d + precision) / 6d));
-        Assert.assertEquals(2, diceDistribution.inverseCumulativeProbability((2d - Double.MIN_VALUE) / 6d));
-        Assert.assertEquals(3, diceDistribution.inverseCumulativeProbability((2d + precision) / 6d));
-        Assert.assertEquals(3, diceDistribution.inverseCumulativeProbability((3d - Double.MIN_VALUE) / 6d));
-        Assert.assertEquals(4, diceDistribution.inverseCumulativeProbability((3d + precision) / 6d));
-        Assert.assertEquals(4, diceDistribution.inverseCumulativeProbability((4d - Double.MIN_VALUE) / 6d));
-        Assert.assertEquals(5, diceDistribution.inverseCumulativeProbability((4d + precision) / 6d));
-        Assert.assertEquals(5, diceDistribution.inverseCumulativeProbability((5d - precision) / 6d)); //Can't use Double.MIN
-        Assert.assertEquals(6, diceDistribution.inverseCumulativeProbability((5d + precision) / 6d));
-        Assert.assertEquals(6, diceDistribution.inverseCumulativeProbability((6d - precision) / 6d)); //Can't use Double.MIN
-        Assert.assertEquals(6, diceDistribution.inverseCumulativeProbability(1d));
+        Assertions.assertEquals(1, diceDistribution.inverseCumulativeProbability(0));
+        Assertions.assertEquals(1, diceDistribution.inverseCumulativeProbability((1d - Double.MIN_VALUE) / 6d));
+        Assertions.assertEquals(2, diceDistribution.inverseCumulativeProbability((1d + precision) / 6d));
+        Assertions.assertEquals(2, diceDistribution.inverseCumulativeProbability((2d - Double.MIN_VALUE) / 6d));
+        Assertions.assertEquals(3, diceDistribution.inverseCumulativeProbability((2d + precision) / 6d));
+        Assertions.assertEquals(3, diceDistribution.inverseCumulativeProbability((3d - Double.MIN_VALUE) / 6d));
+        Assertions.assertEquals(4, diceDistribution.inverseCumulativeProbability((3d + precision) / 6d));
+        Assertions.assertEquals(4, diceDistribution.inverseCumulativeProbability((4d - Double.MIN_VALUE) / 6d));
+        Assertions.assertEquals(5, diceDistribution.inverseCumulativeProbability((4d + precision) / 6d));
+        Assertions.assertEquals(5, diceDistribution.inverseCumulativeProbability((5d - precision) / 6d)); //Can't use Double.MIN
+        Assertions.assertEquals(6, diceDistribution.inverseCumulativeProbability((5d + precision) / 6d));
+        Assertions.assertEquals(6, diceDistribution.inverseCumulativeProbability((6d - precision) / 6d)); //Can't use Double.MIN
+        Assertions.assertEquals(6, diceDistribution.inverseCumulativeProbability(1d));
     }
 
     @Test
     public void testCumulativeProbabilitiesSingleArguments() {
         for (int i = 1; i < 7; i++) {
-            Assert.assertEquals(p * i,
+            Assertions.assertEquals(p * i,
                     diceDistribution.cumulativeProbability(i), Double.MIN_VALUE);
         }
-        Assert.assertEquals(0.0,
+        Assertions.assertEquals(0.0,
                 diceDistribution.cumulativeProbability(0), Double.MIN_VALUE);
-        Assert.assertEquals(1.0,
+        Assertions.assertEquals(1.0,
                 diceDistribution.cumulativeProbability(7), Double.MIN_VALUE);
     }
 
@@ -63,13 +63,13 @@ public class AbstractDiscreteDistributionTest {
         int upper = 6;
         for (int i = 0; i < 2; i++) {
             // cum(0,6) = p(0 < X <= 6) = 1, cum(1,5) = 4/6, cum(2,4) = 2/6
-            Assert.assertEquals(1 - p * 2 * i,
+            Assertions.assertEquals(1 - p * 2 * i,
                     diceDistribution.probability(lower, upper), 1E-12);
             lower++;
             upper--;
         }
         for (int i = 0; i < 6; i++) {
-            Assert.assertEquals(p, diceDistribution.probability(i, i + 1), 1E-12);
+            Assertions.assertEquals(p, diceDistribution.probability(i, i + 1), 1E-12);
         }
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/AbstractDiscreteDistributionTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for AbstractDiscreteDistribution default implementations.

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BetaDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BetaDistributionTest.java
@@ -23,7 +23,7 @@ import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.math3.stat.StatUtils;
 import org.apache.commons.math3.stat.inference.GTest;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BetaDistributionTest {
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BetaDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BetaDistributionTest.java
@@ -22,7 +22,7 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.math3.stat.StatUtils;
 import org.apache.commons.math3.stat.inference.GTest;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BetaDistributionTest {
@@ -152,11 +152,11 @@ public class BetaDistributionTest {
     private void checkCumulative(double alpha, double beta, double[] x, double[] cumes) {
         BetaDistribution d = new BetaDistribution(alpha, beta);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(cumes[i], d.cumulativeProbability(x[i]), 1e-8);
+            Assertions.assertEquals(cumes[i], d.cumulativeProbability(x[i]), 1e-8);
         }
 
         for (int i = 1; i < x.length - 1; i++) {
-            Assert.assertEquals(x[i], d.inverseCumulativeProbability(cumes[i]), 1e-5);
+            Assertions.assertEquals(x[i], d.inverseCumulativeProbability(cumes[i]), 1e-5);
         }
     }
 
@@ -294,7 +294,9 @@ public class BetaDistributionTest {
     private void checkDensity(double alpha, double beta, double[] x, double[] expected) {
         BetaDistribution d = new BetaDistribution(alpha, beta);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(String.format("density at x=%.1f for alpha=%.1f, beta=%.1f", x[i], alpha, beta), expected[i], d.density(x[i]), 1e-5);
+            final int index = i;
+            Assertions.assertEquals(expected[i], d.density(x[i]), 1e-5,
+                () -> String.format("density at x=%.1f for alpha=%.1f, beta=%.1f", x[index], alpha, beta));
         }
     }
 
@@ -304,12 +306,12 @@ public class BetaDistributionTest {
         BetaDistribution dist;
 
         dist = new BetaDistribution(1, 1);
-        Assert.assertEquals(0.5, dist.getMean(), tol);
-        Assert.assertEquals(1.0 / 12.0, dist.getVariance(), tol);
+        Assertions.assertEquals(0.5, dist.getMean(), tol);
+        Assertions.assertEquals(1.0 / 12.0, dist.getVariance(), tol);
 
         dist = new BetaDistribution(2, 5);
-        Assert.assertEquals(2.0 / 7.0, dist.getMean(), tol);
-        Assert.assertEquals(10.0 / (49.0 * 8.0), dist.getVariance(), tol);
+        Assertions.assertEquals(2.0 / 7.0, dist.getMean(), tol);
+        Assertions.assertEquals(10.0 / (49.0 * 8.0), dist.getVariance(), tol);
     }
 
     @Test
@@ -324,13 +326,10 @@ public class BetaDistributionTest {
                         betaDistribution.createSampler(rng));
                 Arrays.sort(observed);
 
-                final String distribution = String.format("Beta(%.2f, %.2f)", alpha, beta);
-                Assert.assertEquals(String.format("E[%s]", distribution),
-                                    betaDistribution.getMean(),
-                                    StatUtils.mean(observed), EPSILON);
-                Assert.assertEquals(String.format("Var[%s]", distribution),
-                                    betaDistribution.getVariance(),
-                                    StatUtils.variance(observed), EPSILON);
+                Assertions.assertEquals(betaDistribution.getMean(), StatUtils.mean(observed),
+                                        EPSILON, () -> String.format("E[Beta(%.2f, %.2f)]", alpha, beta));
+                Assertions.assertEquals(betaDistribution.getVariance(), StatUtils.variance(observed),
+                                        EPSILON, () -> String.format("Var[Beta(%.2f, %.2f)]", alpha, beta));
             }
         }
     }
@@ -350,8 +349,8 @@ public class BetaDistributionTest {
                 final double[] observed = AbstractContinuousDistribution.sample(numSamples, sampler);
 
                 final double gT = gTest(betaDistribution, observed);
-                Assert.assertFalse("G goodness-of-fit (" + gT + ") test rejected null at alpha = " + level,
-                                   gT < level);
+                Assertions.assertFalse(gT < level,
+                    () -> "G goodness-of-fit (" + gT + ") test rejected null at alpha = " + level);
             }
         }
     }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BinomialDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BinomialDistributionTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -108,8 +108,8 @@ public class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         verifyDensities();
         verifyCumulativeProbabilities();
         verifyInverseCumulativeProbabilities();
-        Assert.assertEquals(dist.getSupportLowerBound(), 0);
-        Assert.assertEquals(dist.getSupportUpperBound(), 0);
+        Assertions.assertEquals(dist.getSupportLowerBound(), 0);
+        Assertions.assertEquals(dist.getSupportUpperBound(), 0);
     }
 
     /** Test degenerate case p = 1 */
@@ -126,8 +126,8 @@ public class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         verifyDensities();
         verifyCumulativeProbabilities();
         verifyInverseCumulativeProbabilities();
-        Assert.assertEquals(dist.getSupportLowerBound(), 5);
-        Assert.assertEquals(dist.getSupportUpperBound(), 5);
+        Assertions.assertEquals(dist.getSupportLowerBound(), 5);
+        Assertions.assertEquals(dist.getSupportUpperBound(), 5);
     }
 
     /** Test degenerate case n = 0 */
@@ -144,8 +144,8 @@ public class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         verifyDensities();
         verifyCumulativeProbabilities();
         verifyInverseCumulativeProbabilities();
-        Assert.assertEquals(dist.getSupportLowerBound(), 0);
-        Assert.assertEquals(dist.getSupportUpperBound(), 0);
+        Assertions.assertEquals(dist.getSupportLowerBound(), 0);
+        Assertions.assertEquals(dist.getSupportUpperBound(), 0);
     }
 
     @Test
@@ -154,12 +154,12 @@ public class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         BinomialDistribution dist;
 
         dist = new BinomialDistribution(10, 0.5);
-        Assert.assertEquals(10d * 0.5d, dist.getMean(), tol);
-        Assert.assertEquals(10d * 0.5d * 0.5d, dist.getVariance(), tol);
+        Assertions.assertEquals(10d * 0.5d, dist.getMean(), tol);
+        Assertions.assertEquals(10d * 0.5d * 0.5d, dist.getVariance(), tol);
 
         dist = new BinomialDistribution(30, 0.3);
-        Assert.assertEquals(30d * 0.3d, dist.getMean(), tol);
-        Assert.assertEquals(30d * 0.3d * (1d - 0.3d), dist.getVariance(), tol);
+        Assertions.assertEquals(30d * 0.3d, dist.getMean(), tol);
+        Assertions.assertEquals(30d * 0.3d * (1d - 0.3d), dist.getVariance(), tol);
     }
 
     @Test
@@ -171,7 +171,7 @@ public class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         for (int trials = 500000; trials < 20000000; trials += 100000) {
             BinomialDistribution dist = new BinomialDistribution(trials, 0.5);
             int p = dist.inverseCumulativeProbability(0.5);
-            Assert.assertEquals(trials / 2, p);
+            Assertions.assertEquals(trials / 2, p);
         }
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BinomialDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BinomialDistributionTest.java
@@ -17,7 +17,8 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for BinomialDistribution. Extends DiscreteDistributionAbstractTest.
@@ -26,10 +27,10 @@ import org.junit.Test;
  */
 public class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
 
-    /**
-     * Constructor to override default tolerance.
-     */
-    public BinomialDistributionTest() {
+    // --------------------- Override tolerance  --------------
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-12);
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/CauchyDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/CauchyDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for CauchyDistribution.
@@ -30,9 +32,9 @@ public class CauchyDistributionTest extends ContinuousDistributionAbstractTest {
 
     // --------------------- Override tolerance  --------------
     protected double defaultTolerance = 1e-7;
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(defaultTolerance);
     }
 
@@ -87,13 +89,13 @@ public class CauchyDistributionTest extends ContinuousDistributionAbstractTest {
         Assert.assertEquals(2.1, distribution.getScale(), 0.0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new CauchyDistribution(0, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CauchyDistribution(0, 0));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        new CauchyDistribution(0, -1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CauchyDistribution(0, -1));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/CauchyDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/CauchyDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,13 +79,13 @@ public class CauchyDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testMedian() {
         CauchyDistribution distribution = (CauchyDistribution) getDistribution();
-        Assert.assertEquals(1.2, distribution.getMedian(), 0.0);
+        Assertions.assertEquals(1.2, distribution.getMedian(), 0.0);
     }
 
     @Test
     public void testScale() {
         CauchyDistribution distribution = (CauchyDistribution) getDistribution();
-        Assert.assertEquals(2.1, distribution.getScale(), 0.0);
+        Assertions.assertEquals(2.1, distribution.getScale(), 0.0);
     }
 
     @Test
@@ -103,11 +102,11 @@ public class CauchyDistributionTest extends ContinuousDistributionAbstractTest {
         CauchyDistribution dist;
 
         dist = new CauchyDistribution(10.2, 0.15);
-        Assert.assertTrue(Double.isNaN(dist.getMean()));
-        Assert.assertTrue(Double.isNaN(dist.getVariance()));
+        Assertions.assertTrue(Double.isNaN(dist.getMean()));
+        Assertions.assertTrue(Double.isNaN(dist.getVariance()));
 
         dist = new CauchyDistribution(23.12, 2.12);
-        Assert.assertTrue(Double.isNaN(dist.getMean()));
-        Assert.assertTrue(Double.isNaN(dist.getVariance()));
+        Assertions.assertTrue(Double.isNaN(dist.getMean()));
+        Assertions.assertTrue(Double.isNaN(dist.getVariance()));
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ChiSquaredDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ChiSquaredDistributionTest.java
@@ -18,7 +18,8 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@link ChiSquaredDistribution}.
@@ -72,9 +73,9 @@ public class ChiSquaredDistributionTest extends ContinuousDistributionAbstractTe
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-9);
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ChiSquaredDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ChiSquaredDistributionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -98,7 +98,7 @@ public class ChiSquaredDistributionTest extends ContinuousDistributionAbstractTe
     @Test
     public void testDfAccessors() {
         ChiSquaredDistribution distribution = (ChiSquaredDistribution) getDistribution();
-        Assert.assertEquals(5d, distribution.getDegreesOfFreedom(), Double.MIN_VALUE);
+        Assertions.assertEquals(5d, distribution.getDegreesOfFreedom(), Double.MIN_VALUE);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class ChiSquaredDistributionTest extends ContinuousDistributionAbstractTe
     private void checkDensity(double df, double[] x, double[] expected) {
         ChiSquaredDistribution d = new ChiSquaredDistribution(df);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(expected[i], d.density(x[i]), 1e-5);
+            Assertions.assertEquals(expected[i], d.density(x[i]), 1e-5);
         }
     }
 
@@ -127,11 +127,11 @@ public class ChiSquaredDistributionTest extends ContinuousDistributionAbstractTe
         ChiSquaredDistribution dist;
 
         dist = new ChiSquaredDistribution(1500);
-        Assert.assertEquals(1500, dist.getMean(), tol);
-        Assert.assertEquals(3000, dist.getVariance(), tol);
+        Assertions.assertEquals(1500, dist.getMean(), tol);
+        Assertions.assertEquals(3000, dist.getVariance(), tol);
 
         dist = new ChiSquaredDistribution(1.12);
-        Assert.assertEquals(1.12, dist.getMean(), tol);
-        Assert.assertEquals(2.24, dist.getVariance(), tol);
+        Assertions.assertEquals(1.12, dist.getMean(), tol);
+        Assertions.assertEquals(2.24, dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ConstantContinuousDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ConstantContinuousDistributionTest.java
@@ -18,18 +18,18 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for ConstantContinuousDistribution.
  */
 public class ConstantContinuousDistributionTest extends ContinuousDistributionAbstractTest {
 
-    // --- Override tolerance -------------------------------------------------
+    // --------------------- Override tolerance  --------------
 
-    @Override
-    public void setUp() {
-        super.setUp();
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(0);
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ConstantContinuousDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ConstantContinuousDistributionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,7 +65,7 @@ public class ConstantContinuousDistributionTest extends ContinuousDistributionAb
     public void testInverseCumulativeProbabilities() {
         ContinuousDistribution dist = getDistribution();
         for (double x : getCumulativeTestValues()) {
-            Assert.assertEquals(1, dist.inverseCumulativeProbability(x), 0);
+            Assertions.assertEquals(1, dist.inverseCumulativeProbability(x), 0);
         }
     }
 
@@ -76,8 +76,8 @@ public class ConstantContinuousDistributionTest extends ContinuousDistributionAb
         ConstantContinuousDistribution dist;
 
         dist = new ConstantContinuousDistribution(-1);
-        Assert.assertEquals(-1, dist.getMean(), 0d);
-        Assert.assertEquals(0, dist.getVariance(), 0d);
+        Assertions.assertEquals(-1, dist.getMean(), 0d);
+        Assertions.assertEquals(0, dist.getVariance(), 0d);
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ConstantContinuousDistributionTest extends ContinuousDistributionAb
         final double value = 12.345;
         final ContinuousDistribution.Sampler sampler = new ConstantContinuousDistribution(value).createSampler(null);
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(value, sampler.sample(), 0);
+            Assertions.assertEquals(value, sampler.sample(), 0);
         }
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ContinuousDistributionAbstractTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ContinuousDistributionAbstractTest.java
@@ -24,10 +24,11 @@ import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator;
 import org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Abstract base class for {@link ContinuousDistribution} tests.
@@ -130,9 +131,12 @@ public abstract class ContinuousDistributionAbstractTest {
     //-------------------- Setup / tear down ----------------------------------
 
     /**
-     * Setup sets all test instance data to default values
+     * Setup sets all test instance data to default values.
+     * <p>
+     * This method is @BeforeEach (created for each test) as certain test methods may wish
+     * to alter the defaults.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         distribution = makeDistribution();
         cumulativeTestPoints = makeCumulativeTestPoints();
@@ -146,7 +150,7 @@ public abstract class ContinuousDistributionAbstractTest {
     /**
      * Cleans up test instance data
      */
-    @After
+    @AfterEach
     public void tearDown() {
         distribution = null;
         cumulativeTestPoints = null;
@@ -291,17 +295,17 @@ public abstract class ContinuousDistributionAbstractTest {
     /**
      * Verifies that illegal arguments are correctly handled
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        distribution.probability(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> distribution.probability(1, 0));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        distribution.inverseCumulativeProbability(-1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> distribution.inverseCumulativeProbability(-1));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition3() {
-        distribution.inverseCumulativeProbability(2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> distribution.inverseCumulativeProbability(2));
     }
 
     /**

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ContinuousDistributionAbstractTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ContinuousDistributionAbstractTest.java
@@ -24,7 +24,6 @@ import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator;
 import org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -188,7 +187,7 @@ public abstract class ContinuousDistributionAbstractTest {
                     } catch (IllegalArgumentException e) {
                         continue;
                     }
-                    Assert.fail("distribution.probability(double, double) should have thrown an exception that second argument is too large");
+                    Assertions.fail("distribution.probability(double, double) should have thrown an exception that second argument is too large");
                 }
             }
         }
@@ -357,7 +356,7 @@ public abstract class ContinuousDistributionAbstractTest {
         }
         Collections.sort(integrationTestPoints);
         for (int i = 1; i < integrationTestPoints.size(); i++) {
-            Assert.assertEquals(distribution.probability(integrationTestPoints.get(0), integrationTestPoints.get(i)),
+            Assertions.assertEquals(distribution.probability(integrationTestPoints.get(0), integrationTestPoints.get(i)),
                                 integrator.integrate(1000000, // Triangle integrals are very slow to converge
                                                      d, integrationTestPoints.get(0),
                                                      integrationTestPoints.get(i)), tol);

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/DiscreteDistributionAbstractTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/DiscreteDistributionAbstractTest.java
@@ -17,7 +17,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,9 +152,10 @@ public abstract class DiscreteDistributionAbstractTest {
      */
     protected void verifyDensities() {
         for (int i = 0; i < densityTestPoints.length; i++) {
-            Assert.assertEquals("Incorrect density value returned for " + densityTestPoints[i],
-                                densityTestValues[i],
-                                distribution.probability(densityTestPoints[i]), getTolerance());
+            final int testPoint = densityTestPoints[i];
+            Assertions.assertEquals(densityTestValues[i],
+                distribution.probability(testPoint), getTolerance(),
+                () -> "Incorrect density value returned for " + testPoint);
         }
     }
 
@@ -166,9 +166,10 @@ public abstract class DiscreteDistributionAbstractTest {
     protected void verifyLogDensities() {
         for (int i = 0; i < densityTestPoints.length; i++) {
             // FIXME: when logProbability methods are added to DiscreteDistribution in 4.0, remove cast below
-            Assert.assertEquals("Incorrect log density value returned for " + densityTestPoints[i],
-                                logDensityTestValues[i],
-                                ((AbstractDiscreteDistribution) distribution).logProbability(densityTestPoints[i]), tolerance);
+            final int testPoint = densityTestPoints[i];
+            Assertions.assertEquals(logDensityTestValues[i],
+                ((AbstractDiscreteDistribution) distribution).logProbability(testPoint), tolerance,
+                () -> "Incorrect log density value returned for " + testPoint);
         }
     }
 
@@ -178,9 +179,10 @@ public abstract class DiscreteDistributionAbstractTest {
      */
     protected void verifyCumulativeProbabilities() {
         for (int i = 0; i < cumulativeTestPoints.length; i++) {
-            Assert.assertEquals("Incorrect cumulative probability value returned for " + cumulativeTestPoints[i],
-                                cumulativeTestValues[i],
-                                distribution.cumulativeProbability(cumulativeTestPoints[i]), getTolerance());
+            final int testPoint = cumulativeTestPoints[i];
+            Assertions.assertEquals(cumulativeTestValues[i],
+                distribution.cumulativeProbability(testPoint), getTolerance(),
+                () -> "Incorrect cumulative probability value returned for " + testPoint);
         }
     }
 
@@ -191,9 +193,10 @@ public abstract class DiscreteDistributionAbstractTest {
      */
     protected void verifyInverseCumulativeProbabilities() {
         for (int i = 0; i < inverseCumulativeTestPoints.length; i++) {
-            Assert.assertEquals("Incorrect inverse cumulative probability value returned for " +
-                                inverseCumulativeTestPoints[i], inverseCumulativeTestValues[i],
-                                distribution.inverseCumulativeProbability(inverseCumulativeTestPoints[i]));
+            final double testPoint = inverseCumulativeTestPoints[i];
+            Assertions.assertEquals(inverseCumulativeTestValues[i],
+                distribution.inverseCumulativeProbability(testPoint),
+                () -> "Incorrect inverse cumulative probability value returned for " + testPoint);
         }
     }
 
@@ -238,20 +241,20 @@ public abstract class DiscreteDistributionAbstractTest {
     @Test
     public void testConsistencyAtSupportBounds() {
         final int lower = distribution.getSupportLowerBound();
-        Assert.assertEquals("Cumulative probability mmust be 0 below support lower bound.",
-                            0.0, distribution.cumulativeProbability(lower - 1), 0.0);
-        Assert.assertEquals("Cumulative probability of support lower bound must be equal to probability mass at this point.",
-                            distribution.probability(lower), distribution.cumulativeProbability(lower), getTolerance());
-        Assert.assertEquals("Inverse cumulative probability of 0 must be equal to support lower bound.",
-                            lower, distribution.inverseCumulativeProbability(0.0));
+        Assertions.assertEquals(0.0, distribution.cumulativeProbability(lower - 1), 0.0,
+                "Cumulative probability mmust be 0 below support lower bound.");
+        Assertions.assertEquals(distribution.probability(lower), distribution.cumulativeProbability(lower), getTolerance(),
+                "Cumulative probability of support lower bound must be equal to probability mass at this point.");
+        Assertions.assertEquals(lower, distribution.inverseCumulativeProbability(0.0),
+                "Inverse cumulative probability of 0 must be equal to support lower bound.");
 
         final int upper = distribution.getSupportUpperBound();
         if (upper != Integer.MAX_VALUE) {
-            Assert.assertEquals("Cumulative probability of support upper bound must be equal to 1.",
-                                1.0, distribution.cumulativeProbability(upper), 0.0);
+            Assertions.assertEquals(1.0, distribution.cumulativeProbability(upper), 0.0,
+                    "Cumulative probability of support upper bound must be equal to 1.");
         }
-        Assert.assertEquals("Inverse cumulative probability of 1 must be equal to support upper bound.",
-                            upper, distribution.inverseCumulativeProbability(1.0));
+        Assertions.assertEquals(upper, distribution.inverseCumulativeProbability(1.0),
+                "Inverse cumulative probability of 1 must be equal to support upper bound.");
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/DiscreteDistributionAbstractTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/DiscreteDistributionAbstractTest.java
@@ -17,10 +17,11 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract base class for {@link DiscreteDistribution} tests.
@@ -117,7 +118,7 @@ public abstract class DiscreteDistributionAbstractTest {
     /**
      * Setup sets all test instance data to default values
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         distribution = makeDistribution();
         densityTestPoints = makeDensityTestPoints();
@@ -132,7 +133,7 @@ public abstract class DiscreteDistributionAbstractTest {
     /**
      * Cleans up test instance data
      */
-    @After
+    @AfterEach
     public void tearDown() {
         distribution = null;
         densityTestPoints = null;
@@ -253,17 +254,17 @@ public abstract class DiscreteDistributionAbstractTest {
                             upper, distribution.inverseCumulativeProbability(1.0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        distribution.probability(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> distribution.probability(1, 0));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        distribution.inverseCumulativeProbability(-1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> distribution.inverseCumulativeProbability(-1));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition3() {
-        distribution.inverseCumulativeProbability(2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> distribution.inverseCumulativeProbability(2));
     }
 
     /**

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ExponentialDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ExponentialDistributionTest.java
@@ -17,7 +17,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,31 +85,31 @@ public class ExponentialDistributionTest extends ContinuousDistributionAbstractT
     @Test
     public void testCumulativeProbability2() {
         double actual = getDistribution().probability(0.25, 0.75);
-        Assert.assertEquals(0.0905214, actual, 10e-4);
+        Assertions.assertEquals(0.0905214, actual, 10e-4);
     }
 
     @Test
     public void testDensity() {
         ExponentialDistribution d1 = new ExponentialDistribution(1);
-        Assert.assertTrue(Precision.equals(0.0, d1.density(-1e-9), 1));
-        Assert.assertTrue(Precision.equals(1.0, d1.density(0.0), 1));
-        Assert.assertTrue(Precision.equals(0.0, d1.density(1000.0), 1));
-        Assert.assertTrue(Precision.equals(Math.exp(-1), d1.density(1.0), 1));
-        Assert.assertTrue(Precision.equals(Math.exp(-2), d1.density(2.0), 1));
+        Assertions.assertTrue(Precision.equals(0.0, d1.density(-1e-9), 1));
+        Assertions.assertTrue(Precision.equals(1.0, d1.density(0.0), 1));
+        Assertions.assertTrue(Precision.equals(0.0, d1.density(1000.0), 1));
+        Assertions.assertTrue(Precision.equals(Math.exp(-1), d1.density(1.0), 1));
+        Assertions.assertTrue(Precision.equals(Math.exp(-2), d1.density(2.0), 1));
 
         ExponentialDistribution d2 = new ExponentialDistribution(3);
-        Assert.assertTrue(Precision.equals(1 / 3.0, d2.density(0.0), 1));
+        Assertions.assertTrue(Precision.equals(1 / 3.0, d2.density(0.0), 1));
         // computed using  print(dexp(1, rate=1/3), digits=10) in R 2.5
-        Assert.assertEquals(0.2388437702, d2.density(1.0), 1e-8);
+        Assertions.assertEquals(0.2388437702, d2.density(1.0), 1e-8);
 
         // computed using  print(dexp(2, rate=1/3), digits=10) in R 2.5
-        Assert.assertEquals(0.1711390397, d2.density(2.0), 1e-8);
+        Assertions.assertEquals(0.1711390397, d2.density(2.0), 1e-8);
     }
 
     @Test
     public void testMeanAccessors() {
         ExponentialDistribution distribution = (ExponentialDistribution) getDistribution();
-        Assert.assertEquals(5d, distribution.getMean(), Double.MIN_VALUE);
+        Assertions.assertEquals(5d, distribution.getMean(), Double.MIN_VALUE);
     }
 
     @Test
@@ -124,11 +123,11 @@ public class ExponentialDistributionTest extends ContinuousDistributionAbstractT
         ExponentialDistribution dist;
 
         dist = new ExponentialDistribution(11d);
-        Assert.assertEquals(11d, dist.getMean(), tol);
-        Assert.assertEquals(11d * 11d, dist.getVariance(), tol);
+        Assertions.assertEquals(11d, dist.getMean(), tol);
+        Assertions.assertEquals(11d * 11d, dist.getVariance(), tol);
 
         dist = new ExponentialDistribution(10.5d);
-        Assert.assertEquals(10.5d, dist.getMean(), tol);
-        Assert.assertEquals(10.5d * 10.5d, dist.getVariance(), tol);
+        Assertions.assertEquals(10.5d, dist.getMean(), tol);
+        Assertions.assertEquals(10.5d * 10.5d, dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ExponentialDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ExponentialDistributionTest.java
@@ -18,7 +18,9 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for ExponentialDistribution.
@@ -29,9 +31,9 @@ import org.junit.Test;
 public class ExponentialDistributionTest extends ContinuousDistributionAbstractTest {
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-9);
     }
 
@@ -111,9 +113,9 @@ public class ExponentialDistributionTest extends ContinuousDistributionAbstractT
         Assert.assertEquals(5d, distribution.getMean(), Double.MIN_VALUE);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new ExponentialDistribution(0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ExponentialDistribution(0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/FDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/FDistributionTest.java
@@ -17,7 +17,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for FDistribution.
@@ -57,9 +59,9 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-9);
     }
 
@@ -86,13 +88,13 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
         Assert.assertEquals(6d, dist.getDenominatorDegreesOfFreedom(), Double.MIN_VALUE);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new FDistribution(0, 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new FDistribution(0, 1));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        new FDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new FDistribution(1, 0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/FDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/FDistributionTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,8 +83,8 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testDfAccessors() {
         FDistribution dist = (FDistribution) getDistribution();
-        Assert.assertEquals(5d, dist.getNumeratorDegreesOfFreedom(), Double.MIN_VALUE);
-        Assert.assertEquals(6d, dist.getDenominatorDegreesOfFreedom(), Double.MIN_VALUE);
+        Assertions.assertEquals(5d, dist.getNumeratorDegreesOfFreedom(), Double.MIN_VALUE);
+        Assertions.assertEquals(6d, dist.getDenominatorDegreesOfFreedom(), Double.MIN_VALUE);
     }
 
     @Test
@@ -102,7 +101,7 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
         FDistribution fd = new FDistribution(100000, 100000);
         double p = fd.cumulativeProbability(.999);
         double x = fd.inverseCumulativeProbability(p);
-        Assert.assertEquals(.999, x, 1.0e-5);
+        Assertions.assertEquals(.999, x, 1.0e-5);
     }
 
     @Test
@@ -110,12 +109,12 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
         FDistribution fd = new FDistribution(1, 1);
         double p = fd.cumulativeProbability(0.975);
         double x = fd.inverseCumulativeProbability(p);
-        Assert.assertEquals(0.975, x, 1.0e-5);
+        Assertions.assertEquals(0.975, x, 1.0e-5);
 
         fd = new FDistribution(1, 2);
         p = fd.cumulativeProbability(0.975);
         x = fd.inverseCumulativeProbability(p);
-        Assert.assertEquals(0.975, x, 1.0e-5);
+        Assertions.assertEquals(0.975, x, 1.0e-5);
     }
 
     @Test
@@ -124,16 +123,16 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
         FDistribution dist;
 
         dist = new FDistribution(1, 2);
-        Assert.assertTrue(Double.isNaN(dist.getMean()));
-        Assert.assertTrue(Double.isNaN(dist.getVariance()));
+        Assertions.assertTrue(Double.isNaN(dist.getMean()));
+        Assertions.assertTrue(Double.isNaN(dist.getVariance()));
 
         dist = new FDistribution(1, 3);
-        Assert.assertEquals(3d / (3d - 2d), dist.getMean(), tol);
-        Assert.assertTrue(Double.isNaN(dist.getVariance()));
+        Assertions.assertEquals(3d / (3d - 2d), dist.getMean(), tol);
+        Assertions.assertTrue(Double.isNaN(dist.getVariance()));
 
         dist = new FDistribution(1, 5);
-        Assert.assertEquals(5d / (5d - 2d), dist.getMean(), tol);
-        Assert.assertEquals((2d * 5d * 5d * 4d) / 9d, dist.getVariance(), tol);
+        Assertions.assertEquals(5d / (5d - 2d), dist.getMean(), tol);
+        Assertions.assertEquals((2d * 5d * 5d * 4d) / 9d, dist.getVariance(), tol);
     }
 
     @Test
@@ -144,9 +143,9 @@ public class FDistributionTest extends ContinuousDistributionAbstractTest {
             double prob = 0.01;
             FDistribution f = new FDistribution(200000, 200000);
             double result = f.inverseCumulativeProbability(prob);
-            Assert.assertTrue(result < 1.0);
+            Assertions.assertTrue(result < 1.0);
         } catch (AssertionError ex) {
-            Assert.fail("Failing to calculate inverse cumulative probability");
+            Assertions.fail("Failing to calculate inverse cumulative probability");
         }
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GammaDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GammaDistributionTest.java
@@ -24,7 +24,6 @@ import java.io.InputStreamReader;
 
 import org.apache.commons.numbers.gamma.LanczosApproximation;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,8 +78,8 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testParameterAccessors() {
         GammaDistribution distribution = (GammaDistribution) getDistribution();
-        Assert.assertEquals(4d, distribution.getShape(), 0);
-        Assert.assertEquals(2d, distribution.getScale(), 0);
+        Assertions.assertEquals(4d, distribution.getShape(), 0);
+        Assertions.assertEquals(2d, distribution.getScale(), 0);
     }
 
     @Test
@@ -112,13 +111,13 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
     private void testProbability(double x, double a, double b, double expected) {
         GammaDistribution distribution = new GammaDistribution(a, b);
         double actual = distribution.cumulativeProbability(x);
-        Assert.assertEquals("probability for " + x, expected, actual, 10e-4);
+        Assertions.assertEquals(expected, actual, 10e-4, () -> "probability for " + x);
     }
 
     private void testValue(double expected, double a, double b, double p) {
         GammaDistribution distribution = new GammaDistribution(a, b);
         double actual = distribution.inverseCumulativeProbability(p);
-        Assert.assertEquals("critical value for " + p, expected, actual, 10e-4);
+        Assertions.assertEquals(expected, actual, 10e-4, () -> "critical value for " + p);
     }
 
     @Test
@@ -145,7 +144,7 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
     private void checkDensity(double alpha, double rate, double[] x, double[] expected) {
         GammaDistribution d = new GammaDistribution(alpha, 1 / rate);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(expected[i], d.density(x[i]), 1e-5);
+            Assertions.assertEquals(expected[i], d.density(x[i]), 1e-5);
         }
     }
 
@@ -162,12 +161,12 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
         GammaDistribution dist;
 
         dist = new GammaDistribution(1, 2);
-        Assert.assertEquals(2, dist.getMean(), tol);
-        Assert.assertEquals(4, dist.getVariance(), tol);
+        Assertions.assertEquals(2, dist.getMean(), tol);
+        Assertions.assertEquals(4, dist.getVariance(), tol);
 
         dist = new GammaDistribution(1.1, 4.2);
-        Assert.assertEquals(1.1d * 4.2d, dist.getMean(), tol);
-        Assert.assertEquals(1.1d * 4.2d * 4.2d, dist.getVariance(), tol);
+        Assertions.assertEquals(1.1d * 4.2d, dist.getMean(), tol);
+        Assertions.assertEquals(1.1d * 4.2d * 4.2d, dist.getVariance(), tol);
     }
 
     public static double logGamma(double x) {
@@ -224,8 +223,7 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
 
         final InputStream resourceAsStream;
         resourceAsStream = this.getClass().getResourceAsStream(resourceName);
-        Assert.assertNotNull("Could not find resource " + resourceName,
-                             resourceAsStream);
+        Assertions.assertNotNull(resourceAsStream, () -> "Could not find resource " + resourceName);
         final BufferedReader in;
         in = new BufferedReader(new InputStreamReader(resourceAsStream));
 
@@ -235,8 +233,7 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
                     continue;
                 }
                 final String[] tokens = line.split(", ");
-                Assert.assertTrue("expected two floating-point values",
-                                  tokens.length == 2);
+                Assertions.assertTrue(tokens.length == 2, "expected two floating-point values");
                 final double x = Double.parseDouble(tokens[0]);
                 final String msg = "x = " + x + ", shape = " + shape +
                                    ", scale = 1.0";
@@ -248,8 +245,8 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
                 final double errNew = Math.abs((actualNew - expected) / ulp);
 
                 if (Double.isNaN(actualOld) || Double.isInfinite(actualOld)) {
-                    Assert.assertFalse(msg, Double.isNaN(actualNew));
-                    Assert.assertFalse(msg, Double.isInfinite(actualNew));
+                    Assertions.assertFalse(Double.isNaN(actualNew), msg);
+                    Assertions.assertFalse(Double.isInfinite(actualNew), msg);
                     statNewOF.addValue(errNew);
                 } else {
                     statOld.addValue(errOld);
@@ -274,22 +271,22 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
 
                 final double oldMin = statOld.getMin();
                 final double newMin = statNewNoOF.getMin();
-                Assert.assertTrue(msg, newMin <= oldMin);
+                Assertions.assertTrue(newMin <= oldMin, msg);
 
                 final double oldMax = statOld.getMax();
                 final double newMax = statNewNoOF.getMax();
-                Assert.assertTrue(msg, newMax <= oldMax);
+                Assertions.assertTrue(newMax <= oldMax, msg);
 
                 final double oldMean = statOld.getMean();
                 final double newMean = statNewNoOF.getMean();
-                Assert.assertTrue(msg, newMean <= oldMean);
+                Assertions.assertTrue(newMean <= oldMean, msg);
 
                 final double oldSd = statOld.getStandardDeviation();
                 final double newSd = statNewNoOF.getStandardDeviation();
-                Assert.assertTrue(msg, newSd <= oldSd);
+                Assertions.assertTrue(newSd <= oldSd, msg);
 
-                Assert.assertTrue(msg, newMean <= meanNoOF);
-                Assert.assertTrue(msg, newSd <= sdNoOF);
+                Assertions.assertTrue(newMean <= meanNoOF, msg);
+                Assertions.assertTrue(newSd <= sdNoOF, msg);
             }
             if (statNewOF.getN() != 0) {
                 final double newMean = statNewOF.getMean();
@@ -308,11 +305,11 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
                 sb.append(newSd);
                 final String msg = sb.toString();
 
-                Assert.assertTrue(msg, newMean <= meanOF);
-                Assert.assertTrue(msg, newSd <= sdOF);
+                Assertions.assertTrue(newMean <= meanOF, msg);
+                Assertions.assertTrue(newSd <= sdOF, msg);
             }
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         } finally {
             in.close();
         }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GammaDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GammaDistributionTest.java
@@ -25,7 +25,9 @@ import java.io.InputStreamReader;
 import org.apache.commons.numbers.gamma.LanczosApproximation;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for GammaDistribution.
@@ -67,9 +69,9 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-9);
     }
 
@@ -81,13 +83,13 @@ public class GammaDistributionTest extends ContinuousDistributionAbstractTest {
         Assert.assertEquals(2d, distribution.getScale(), 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new GammaDistribution(0, 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new GammaDistribution(0, 1));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        new GammaDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new GammaDistribution(1, 0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GeometricDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GeometricDistributionTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -161,11 +161,11 @@ public class GeometricDistributionTest extends DiscreteDistributionAbstractTest 
         GeometricDistribution dist;
 
         dist = new GeometricDistribution(0.5);
-        Assert.assertEquals((1.0d - 0.5d) / 0.5d, dist.getMean(), tol);
-        Assert.assertEquals((1.0d - 0.5d) / (0.5d * 0.5d), dist.getVariance(), tol);
+        Assertions.assertEquals((1.0d - 0.5d) / 0.5d, dist.getMean(), tol);
+        Assertions.assertEquals((1.0d - 0.5d) / (0.5d * 0.5d), dist.getVariance(), tol);
 
         dist = new GeometricDistribution(0.3);
-        Assert.assertEquals((1.0d - 0.3d) / 0.3d, dist.getMean(), tol);
-        Assert.assertEquals((1.0d - 0.3d) / (0.3d * 0.3d), dist.getVariance(), tol);
+        Assertions.assertEquals((1.0d - 0.3d) / 0.3d, dist.getMean(), tol);
+        Assertions.assertEquals((1.0d - 0.3d) / (0.3d * 0.3d), dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GeometricDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GeometricDistributionTest.java
@@ -17,7 +17,8 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for GeometricDistribution.
@@ -25,10 +26,10 @@ import org.junit.Test;
  */
 public class GeometricDistributionTest extends DiscreteDistributionAbstractTest {
 
-    /**
-     * Constructor to override default tolerance.
-     */
-    public GeometricDistributionTest() {
+    // --------------------- Override tolerance  --------------
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-12);
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GumbelDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GumbelDistributionTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -28,16 +28,16 @@ public class GumbelDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testParameters() {
         GumbelDistribution d = makeDistribution();
-        Assert.assertEquals(0.5, d.getLocation(), Precision.EPSILON);
-        Assert.assertEquals(2, d.getScale(), Precision.EPSILON);
+        Assertions.assertEquals(0.5, d.getLocation(), Precision.EPSILON);
+        Assertions.assertEquals(2, d.getScale(), Precision.EPSILON);
     }
 
     @Test
     public void testSupport() {
         GumbelDistribution d = makeDistribution();
-        Assert.assertTrue(Double.isInfinite(d.getSupportLowerBound()));
-        Assert.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
-        Assert.assertTrue(d.isSupportConnected());
+        Assertions.assertTrue(Double.isInfinite(d.getSupportLowerBound()));
+        Assertions.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
+        Assertions.assertTrue(d.isSupportConnected());
     }
 
     @Override

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GumbelDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GumbelDistributionTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for GumbelDistribution.

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/HypergeometricDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/HypergeometricDistributionTest.java
@@ -20,7 +20,9 @@ package org.apache.commons.statistics.distribution;
 import org.apache.commons.numbers.core.Precision;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for HyperGeometriclDistribution.
@@ -30,10 +32,10 @@ import org.junit.Test;
  */
 public class HypergeometricDistributionTest extends DiscreteDistributionAbstractTest {
 
-    /**
-     * Constructor to override default tolerance.
-     */
-    public HypergeometricDistributionTest() {
+    // --------------------- Override tolerance  --------------
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-12);
     }
 
@@ -157,25 +159,25 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         Assert.assertEquals(3, dist.getSupportUpperBound());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new HypergeometricDistribution(0, 3, 5);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HypergeometricDistribution(0, 3, 5));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        new HypergeometricDistribution(5, -1, 5);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HypergeometricDistribution(5, -1, 5));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition3() {
-        new HypergeometricDistribution(5, 3, -1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HypergeometricDistribution(5, 3, -1));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition4() {
-        new HypergeometricDistribution(5, 6, 5);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HypergeometricDistribution(5, 6, 5));
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition5() {
-        new HypergeometricDistribution(5, 3, 6);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HypergeometricDistribution(5, 3, 6));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/HypergeometricDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/HypergeometricDistributionTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,8 +118,8 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         verifyDensities();
         verifyCumulativeProbabilities();
         verifyInverseCumulativeProbabilities();
-        Assert.assertEquals(3, dist.getSupportLowerBound());
-        Assert.assertEquals(3, dist.getSupportUpperBound());
+        Assertions.assertEquals(3, dist.getSupportLowerBound());
+        Assertions.assertEquals(3, dist.getSupportUpperBound());
     }
 
     /** Verify that if there are no successes, mass is concentrated on 0 */
@@ -137,8 +136,8 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         verifyDensities();
         verifyCumulativeProbabilities();
         verifyInverseCumulativeProbabilities();
-        Assert.assertEquals(0, dist.getSupportLowerBound());
-        Assert.assertEquals(0, dist.getSupportUpperBound());
+        Assertions.assertEquals(0, dist.getSupportLowerBound());
+        Assertions.assertEquals(0, dist.getSupportUpperBound());
     }
 
     /** Verify that if sampleSize = populationSize, mass is concentrated on numberOfSuccesses */
@@ -155,8 +154,8 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         verifyDensities();
         verifyCumulativeProbabilities();
         verifyInverseCumulativeProbabilities();
-        Assert.assertEquals(3, dist.getSupportLowerBound());
-        Assert.assertEquals(3, dist.getSupportUpperBound());
+        Assertions.assertEquals(3, dist.getSupportLowerBound());
+        Assertions.assertEquals(3, dist.getSupportUpperBound());
     }
 
     @Test
@@ -183,9 +182,9 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
     @Test
     public void testAccessors() {
         HypergeometricDistribution dist = new HypergeometricDistribution(5, 3, 4);
-        Assert.assertEquals(5, dist.getPopulationSize());
-        Assert.assertEquals(3, dist.getNumberOfSuccesses());
-        Assert.assertEquals(4, dist.getSampleSize());
+        Assertions.assertEquals(5, dist.getPopulationSize());
+        Assertions.assertEquals(3, dist.getNumberOfSuccesses());
+        Assertions.assertEquals(4, dist.getSampleSize());
     }
 
     @Test
@@ -270,12 +269,12 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         HypergeometricDistribution dist;
 
         dist = new HypergeometricDistribution(1500, 40, 100);
-        Assert.assertEquals(40d * 100d / 1500d, dist.getMean(), tol);
-        Assert.assertEquals((100d * 40d * (1500d - 100d) * (1500d - 40d)) / ((1500d * 1500d * 1499d)), dist.getVariance(), tol);
+        Assertions.assertEquals(40d * 100d / 1500d, dist.getMean(), tol);
+        Assertions.assertEquals((100d * 40d * (1500d - 100d) * (1500d - 40d)) / ((1500d * 1500d * 1499d)), dist.getVariance(), tol);
 
         dist = new HypergeometricDistribution(3000, 55, 200);
-        Assert.assertEquals(55d * 200d / 3000d, dist.getMean(), tol);
-        Assert.assertEquals((200d * 55d * (3000d - 200d) * (3000d - 55d)) / ((3000d * 3000d * 2999d)), dist.getVariance(), tol);
+        Assertions.assertEquals(55d * 200d / 3000d, dist.getMean(), tol);
+        Assertions.assertEquals((200d * 55d * (3000d - 200d) * (3000d - 55d)) / ((3000d * 3000d * 2999d)), dist.getVariance(), tol);
     }
 
     @Test
@@ -287,12 +286,12 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         final int k = 0;
         final HypergeometricDistribution dist = new HypergeometricDistribution(N, m, n);
 
-        Assert.assertTrue(Precision.compareTo(1.0, dist.upperCumulativeProbability(k), 1) == 0);
-        Assert.assertTrue(Precision.compareTo(dist.cumulativeProbability(k), 0.0, 1) > 0);
+        Assertions.assertTrue(Precision.compareTo(1.0, dist.upperCumulativeProbability(k), 1) == 0);
+        Assertions.assertTrue(Precision.compareTo(dist.cumulativeProbability(k), 0.0, 1) > 0);
 
         // another way to calculate the upper cumulative probability
         double upper = 1.0 - dist.cumulativeProbability(k) + dist.probability(k);
-        Assert.assertTrue(Precision.compareTo(1.0, upper, 1) == 0);
+        Assertions.assertTrue(Precision.compareTo(1.0, upper, 1) == 0);
     }
 
     @Test
@@ -305,7 +304,7 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
 
         for (int i = 1; i <= n; i++) {
             final double p = dist.probability(i);
-            Assert.assertEquals("p=" + p, 0, p, 0d);
+            Assertions.assertEquals(0, p, 0d, () -> "p=" + p);
         }
     }
 
@@ -317,7 +316,7 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
         for (int s = 0; s <= n; s++) {
             final HypergeometricDistribution dist = new HypergeometricDistribution(n, m, s);
             final double p = dist.probability(s);
-            Assert.assertEquals("p=" + p, 1, p, 0d);
+            Assertions.assertEquals(1, p, 0d, () -> "p=" + p);
         }
     }
 
@@ -331,8 +330,8 @@ public class HypergeometricDistributionTest extends DiscreteDistributionAbstract
 
         for (int i = 0; i < 100; i++) {
             final int sample = dist.sample();
-            Assert.assertTrue("sample=" + sample, 0 <= sample);
-            Assert.assertTrue("sample=" + sample, sample <= n);
+            Assertions.assertTrue(0 <= sample, () -> "sample=" + sample);
+            Assertions.assertTrue(sample <= n, () -> "sample=" + sample);
         }
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LaplaceDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LaplaceDistributionTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for LaplaceDistribution.

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LaplaceDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LaplaceDistributionTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -28,16 +28,16 @@ public class LaplaceDistributionTest extends ContinuousDistributionAbstractTest 
     @Test
     public void testParameters() {
         LaplaceDistribution d = makeDistribution();
-        Assert.assertEquals(0, d.getLocation(), Precision.EPSILON);
-        Assert.assertEquals(1, d.getScale(), Precision.EPSILON);
+        Assertions.assertEquals(0, d.getLocation(), Precision.EPSILON);
+        Assertions.assertEquals(1, d.getScale(), Precision.EPSILON);
     }
 
     @Test
     public void testSupport() {
         LaplaceDistribution d = makeDistribution();
-        Assert.assertTrue(Double.isInfinite(d.getSupportLowerBound()));
-        Assert.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
-        Assert.assertTrue(d.isSupportConnected());
+        Assertions.assertTrue(Double.isInfinite(d.getSupportLowerBound()));
+        Assertions.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
+        Assertions.assertTrue(d.isSupportConnected());
     }
 
     @Override

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LevyDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LevyDistributionTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class LevyDistributionTest extends ContinuousDistributionAbstractTest {
@@ -25,16 +25,16 @@ public class LevyDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testParameters() {
         LevyDistribution d = makeDistribution();
-        Assert.assertEquals(1.2, d.getLocation(), Precision.EPSILON);
-        Assert.assertEquals(0.4,   d.getScale(),  Precision.EPSILON);
+        Assertions.assertEquals(1.2, d.getLocation(), Precision.EPSILON);
+        Assertions.assertEquals(0.4,   d.getScale(),  Precision.EPSILON);
     }
 
     @Test
     public void testSupport() {
         LevyDistribution d = makeDistribution();
-        Assert.assertEquals(d.getLocation(), d.getSupportLowerBound(), Precision.EPSILON);
-        Assert.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
-        Assert.assertTrue(d.isSupportConnected());
+        Assertions.assertEquals(d.getLocation(), d.getSupportLowerBound(), Precision.EPSILON);
+        Assertions.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
+        Assertions.assertTrue(d.isSupportConnected());
     }
 
     @Override

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LevyDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LevyDistributionTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LevyDistributionTest extends ContinuousDistributionAbstractTest {
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogNormalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogNormalDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -163,13 +162,13 @@ public class LogNormalDistributionTest extends ContinuousDistributionAbstractTes
     @Test
     public void testGetScale() {
         LogNormalDistribution distribution = (LogNormalDistribution)getDistribution();
-        Assert.assertEquals(2.1, distribution.getScale(), 0);
+        Assertions.assertEquals(2.1, distribution.getScale(), 0);
     }
 
     @Test
     public void testGetShape() {
         LogNormalDistribution distribution = (LogNormalDistribution)getDistribution();
-        Assert.assertEquals(1.4, distribution.getShape(), 0);
+        Assertions.assertEquals(1.4, distribution.getShape(), 0);
     }
 
     @Test
@@ -196,7 +195,7 @@ public class LogNormalDistributionTest extends ContinuousDistributionAbstractTes
                               double[] expected) {
         LogNormalDistribution d = new LogNormalDistribution(scale, shape);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(expected[i], d.density(x[i]), 1e-9);
+            Assertions.assertEquals(expected[i], d.density(x[i]), 1e-9);
         }
     }
 
@@ -210,16 +209,16 @@ public class LogNormalDistributionTest extends ContinuousDistributionAbstractTes
         for (int i = 0; i < 1e5; i++) { // make sure no convergence exception
             double upperTail = d.cumulativeProbability(i);
             if (i <= 72) { // make sure not top-coded
-                Assert.assertTrue(upperTail < 1.0d);
+                Assertions.assertTrue(upperTail < 1.0d);
             } else { // make sure top coding not reversed
-                Assert.assertTrue(upperTail > 0.99999);
+                Assertions.assertTrue(upperTail > 0.99999);
             }
         }
 
-        Assert.assertEquals(1, d.cumulativeProbability(Double.MAX_VALUE), 0);
-        Assert.assertEquals(0, d.cumulativeProbability(-Double.MAX_VALUE), 0);
-        Assert.assertEquals(1, d.cumulativeProbability(Double.POSITIVE_INFINITY), 0);
-        Assert.assertEquals(0, d.cumulativeProbability(Double.NEGATIVE_INFINITY), 0);
+        Assertions.assertEquals(1, d.cumulativeProbability(Double.MAX_VALUE), 0);
+        Assertions.assertEquals(0, d.cumulativeProbability(-Double.MAX_VALUE), 0);
+        Assertions.assertEquals(1, d.cumulativeProbability(Double.POSITIVE_INFINITY), 0);
+        Assertions.assertEquals(0, d.cumulativeProbability(Double.NEGATIVE_INFINITY), 0);
     }
 
     @Test
@@ -228,22 +227,22 @@ public class LogNormalDistributionTest extends ContinuousDistributionAbstractTes
         LogNormalDistribution dist;
 
         dist = new LogNormalDistribution(0, 1);
-        Assert.assertEquals(1.6487212707001282, dist.getMean(), tol);
-        Assert.assertEquals(4.670774270471604, dist.getVariance(), tol);
+        Assertions.assertEquals(1.6487212707001282, dist.getMean(), tol);
+        Assertions.assertEquals(4.670774270471604, dist.getVariance(), tol);
 
         dist = new LogNormalDistribution(2.2, 1.4);
-        Assert.assertEquals(24.046753552064498, dist.getMean(), tol);
-        Assert.assertEquals(3526.913651880464, dist.getVariance(), tol);
+        Assertions.assertEquals(24.046753552064498, dist.getMean(), tol);
+        Assertions.assertEquals(3526.913651880464, dist.getVariance(), tol);
 
         dist = new LogNormalDistribution(-2000.9, 10.4);
-        Assert.assertEquals(0.0, dist.getMean(), tol);
-        Assert.assertEquals(0.0, dist.getVariance(), tol);
+        Assertions.assertEquals(0.0, dist.getMean(), tol);
+        Assertions.assertEquals(0.0, dist.getVariance(), tol);
     }
 
     @Test
     public void testTinyVariance() {
         LogNormalDistribution dist = new LogNormalDistribution(0, 1e-9);
         double t = dist.getVariance();
-        Assert.assertEquals(1e-18, t, 1e-20);
+        Assertions.assertEquals(1e-18, t, 1e-20);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogNormalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogNormalDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@link LogNormalDistribution}. Extends
@@ -95,9 +97,9 @@ public class LogNormalDistributionTest extends ContinuousDistributionAbstractTes
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-7);
     }
 
@@ -170,9 +172,9 @@ public class LogNormalDistributionTest extends ContinuousDistributionAbstractTes
         Assert.assertEquals(1.4, distribution.getShape(), 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new LogNormalDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogNormalDistribution(1, 0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogisticsDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogisticsDistributionTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for LogisticsDistribution.

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogisticsDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogisticsDistributionTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -28,16 +28,16 @@ public class LogisticsDistributionTest extends ContinuousDistributionAbstractTes
     @Test
     public void testParameters() {
         LogisticDistribution d = makeDistribution();
-        Assert.assertEquals(2, d.getLocation(), Precision.EPSILON);
-        Assert.assertEquals(5, d.getScale(), Precision.EPSILON);
+        Assertions.assertEquals(2, d.getLocation(), Precision.EPSILON);
+        Assertions.assertEquals(5, d.getScale(), Precision.EPSILON);
     }
 
     @Test
     public void testSupport() {
         LogisticDistribution d = makeDistribution();
-        Assert.assertTrue(Double.isInfinite(d.getSupportLowerBound()));
-        Assert.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
-        Assert.assertTrue(d.isSupportConnected());
+        Assertions.assertTrue(Double.isInfinite(d.getSupportLowerBound()));
+        Assertions.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
+        Assertions.assertTrue(d.isSupportConnected());
     }
 
     @Override

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NakagamiDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NakagamiDistributionTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -28,16 +28,16 @@ public class NakagamiDistributionTest extends ContinuousDistributionAbstractTest
     @Test
     public void testParameters() {
         NakagamiDistribution d = makeDistribution();
-        Assert.assertEquals(0.5, d.getShape(), Precision.EPSILON);
-        Assert.assertEquals(1, d.getScale(), Precision.EPSILON);
+        Assertions.assertEquals(0.5, d.getShape(), Precision.EPSILON);
+        Assertions.assertEquals(1, d.getScale(), Precision.EPSILON);
     }
 
     @Test
     public void testSupport() {
         NakagamiDistribution d = makeDistribution();
-        Assert.assertEquals(d.getSupportLowerBound(), 0, Precision.EPSILON);
-        Assert.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
-        Assert.assertTrue(d.isSupportConnected());
+        Assertions.assertEquals(d.getSupportLowerBound(), 0, Precision.EPSILON);
+        Assertions.assertTrue(Double.isInfinite(d.getSupportUpperBound()));
+        Assertions.assertTrue(d.isSupportConnected());
     }
 
     @Override

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NakagamiDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NakagamiDistributionTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.core.Precision;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for NakagamiDistribution.

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NormalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NormalDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@link NormalDistribution}. Extends
@@ -61,9 +63,9 @@ public class NormalDistributionTest extends ContinuousDistributionAbstractTest {
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(DEFAULT_TOLERANCE);
     }
 
@@ -133,9 +135,9 @@ public class NormalDistributionTest extends ContinuousDistributionAbstractTest {
         Assert.assertEquals(1.4, distribution.getStandardDeviation(), 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new NormalDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new NormalDistribution(1, 0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NormalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NormalDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -120,19 +119,19 @@ public class NormalDistributionTest extends ContinuousDistributionAbstractTest {
         double expected = 7.61985e-24;
         double v = dist.cumulativeProbability(x);
         double tol = 1e-5;
-        Assert.assertEquals(1, v / expected, 1e-5);
+        Assertions.assertEquals(1, v / expected, 1e-5);
     }
 
     @Test
     public void testGetMean() {
         NormalDistribution distribution = (NormalDistribution) getDistribution();
-        Assert.assertEquals(2.1, distribution.getMean(), 0);
+        Assertions.assertEquals(2.1, distribution.getMean(), 0);
     }
 
     @Test
     public void testGetStandardDeviation() {
         NormalDistribution distribution = (NormalDistribution) getDistribution();
-        Assert.assertEquals(1.4, distribution.getStandardDeviation(), 0);
+        Assertions.assertEquals(1.4, distribution.getStandardDeviation(), 0);
     }
 
     @Test
@@ -152,7 +151,7 @@ public class NormalDistributionTest extends ContinuousDistributionAbstractTest {
     private void checkDensity(double mean, double sd, double[] x, double[] expected) {
         NormalDistribution d = new NormalDistribution(mean, sd);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(expected[i], d.density(x[i]), 1e-9);
+            Assertions.assertEquals(expected[i], d.density(x[i]), 1e-9);
         }
     }
 
@@ -169,31 +168,31 @@ public class NormalDistributionTest extends ContinuousDistributionAbstractTest {
             if (i < 9) { // make sure not top-coded
                 // For i = 10, due to bad tail precision in erf (MATH-364), 1 is returned
                 // TODO: once MATH-364 is resolved, replace 9 with 30
-                Assert.assertTrue(lowerTail > 0.0d);
-                Assert.assertTrue(upperTail < 1.0d);
+                Assertions.assertTrue(lowerTail > 0.0d);
+                Assertions.assertTrue(upperTail < 1.0d);
             } else { // make sure top coding not reversed
-                Assert.assertTrue(lowerTail < 0.00001);
-                Assert.assertTrue(upperTail > 0.99999);
+                Assertions.assertTrue(lowerTail < 0.00001);
+                Assertions.assertTrue(upperTail > 0.99999);
             }
         }
 
-        Assert.assertEquals(1, distribution.cumulativeProbability(Double.MAX_VALUE), 0);
-        Assert.assertEquals(0, distribution.cumulativeProbability(-Double.MAX_VALUE), 0);
-        Assert.assertEquals(1, distribution.cumulativeProbability(Double.POSITIVE_INFINITY), 0);
-        Assert.assertEquals(0, distribution.cumulativeProbability(Double.NEGATIVE_INFINITY), 0);
+        Assertions.assertEquals(1, distribution.cumulativeProbability(Double.MAX_VALUE), 0);
+        Assertions.assertEquals(0, distribution.cumulativeProbability(-Double.MAX_VALUE), 0);
+        Assertions.assertEquals(1, distribution.cumulativeProbability(Double.POSITIVE_INFINITY), 0);
+        Assertions.assertEquals(0, distribution.cumulativeProbability(Double.NEGATIVE_INFINITY), 0);
     }
 
     @Test
     public void testMath280() {
         NormalDistribution normal = new NormalDistribution(0, 1);
         double result = normal.inverseCumulativeProbability(0.9986501019683698);
-        Assert.assertEquals(3.0, result, DEFAULT_TOLERANCE);
+        Assertions.assertEquals(3.0, result, DEFAULT_TOLERANCE);
         result = normal.inverseCumulativeProbability(0.841344746068543);
-        Assert.assertEquals(1.0, result, DEFAULT_TOLERANCE);
+        Assertions.assertEquals(1.0, result, DEFAULT_TOLERANCE);
         result = normal.inverseCumulativeProbability(0.9999683287581673);
-        Assert.assertEquals(4.0, result, DEFAULT_TOLERANCE);
+        Assertions.assertEquals(4.0, result, DEFAULT_TOLERANCE);
         result = normal.inverseCumulativeProbability(0.9772498680518209);
-        Assert.assertEquals(2.0, result, DEFAULT_TOLERANCE);
+        Assertions.assertEquals(2.0, result, DEFAULT_TOLERANCE);
     }
 
     @Test
@@ -202,15 +201,15 @@ public class NormalDistributionTest extends ContinuousDistributionAbstractTest {
         NormalDistribution dist;
 
         dist = new NormalDistribution(0, 1);
-        Assert.assertEquals(0, dist.getMean(), tol);
-        Assert.assertEquals(1, dist.getVariance(), tol);
+        Assertions.assertEquals(0, dist.getMean(), tol);
+        Assertions.assertEquals(1, dist.getVariance(), tol);
 
         dist = new NormalDistribution(2.2, 1.4);
-        Assert.assertEquals(2.2, dist.getMean(), tol);
-        Assert.assertEquals(1.4 * 1.4, dist.getVariance(), tol);
+        Assertions.assertEquals(2.2, dist.getMean(), tol);
+        Assertions.assertEquals(1.4 * 1.4, dist.getVariance(), tol);
 
         dist = new NormalDistribution(-2000.9, 10.4);
-        Assert.assertEquals(-2000.9, dist.getMean(), tol);
-        Assert.assertEquals(10.4 * 10.4, dist.getVariance(), tol);
+        Assertions.assertEquals(-2000.9, dist.getMean(), tol);
+        Assertions.assertEquals(10.4 * 10.4, dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ParetoDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ParetoDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -134,13 +133,13 @@ public class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testGetScale() {
         ParetoDistribution distribution = (ParetoDistribution)getDistribution();
-        Assert.assertEquals(2.1, distribution.getScale(), 0);
+        Assertions.assertEquals(2.1, distribution.getScale(), 0);
     }
 
     @Test
     public void testGetShape() {
         ParetoDistribution distribution = (ParetoDistribution)getDistribution();
-        Assert.assertEquals(1.4, distribution.getShape(), 0);
+        Assertions.assertEquals(1.4, distribution.getShape(), 0);
     }
 
     @Test
@@ -161,7 +160,7 @@ public class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
         double[] expected) {
         ParetoDistribution d = new ParetoDistribution(scale, shape);
         for (int i = 0; i < x.length; i++) {
-            Assert.assertEquals(expected[i], d.density(x[i]), 1e-9);
+            Assertions.assertEquals(expected[i], d.density(x[i]), 1e-9);
         }
     }
 
@@ -174,16 +173,16 @@ public class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
         for (int i = 0; i < 1e5; i++) { // make sure no convergence exception
             double upperTail = d.cumulativeProbability(i);
             if (i <= 1000) { // make sure not top-coded
-                Assert.assertTrue(upperTail < 1.0d);
+                Assertions.assertTrue(upperTail < 1.0d);
             } else { // make sure top coding not reversed
-                Assert.assertTrue(upperTail > 0.999);
+                Assertions.assertTrue(upperTail > 0.999);
             }
         }
 
-        Assert.assertEquals(1, d.cumulativeProbability(Double.MAX_VALUE), 0);
-        Assert.assertEquals(0, d.cumulativeProbability(-Double.MAX_VALUE), 0);
-        Assert.assertEquals(1, d.cumulativeProbability(Double.POSITIVE_INFINITY), 0);
-        Assert.assertEquals(0, d.cumulativeProbability(Double.NEGATIVE_INFINITY), 0);
+        Assertions.assertEquals(1, d.cumulativeProbability(Double.MAX_VALUE), 0);
+        Assertions.assertEquals(0, d.cumulativeProbability(-Double.MAX_VALUE), 0);
+        Assertions.assertEquals(1, d.cumulativeProbability(Double.POSITIVE_INFINITY), 0);
+        Assertions.assertEquals(0, d.cumulativeProbability(Double.NEGATIVE_INFINITY), 0);
     }
 
     @Test
@@ -192,11 +191,11 @@ public class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
         ParetoDistribution dist;
 
         dist = new ParetoDistribution(1, 1);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, dist.getMean(), tol);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, dist.getVariance(), tol);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, dist.getMean(), tol);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, dist.getVariance(), tol);
 
         dist = new ParetoDistribution(2.2, 2.4);
-        Assert.assertEquals(3.771428571428, dist.getMean(), tol);
-        Assert.assertEquals(14.816326530, dist.getVariance(), tol);
+        Assertions.assertEquals(3.771428571428, dist.getMean(), tol);
+        Assertions.assertEquals(14.816326530, dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ParetoDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ParetoDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@link ParetoDistribution}.
@@ -83,9 +85,9 @@ public class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-7);
     }
 
@@ -141,9 +143,9 @@ public class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
         Assert.assertEquals(1.4, distribution.getShape(), 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new ParetoDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ParetoDistribution(1, 0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PascalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PascalDistributionTest.java
@@ -17,7 +17,8 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for PascalDistribution.
@@ -30,9 +31,8 @@ public class PascalDistributionTest extends DiscreteDistributionAbstractTest {
     // --------------------- Override tolerance  --------------
     protected double defaultTolerance = 1e-7;
 
-    @Override
-    public void setUp() {
-        super.setUp();
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(defaultTolerance);
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PascalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PascalDistributionTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -123,11 +123,11 @@ public class PascalDistributionTest extends DiscreteDistributionAbstractTest {
         PascalDistribution dist;
 
         dist = new PascalDistribution(10, 0.5);
-        Assert.assertEquals((10d * 0.5d) / 0.5d, dist.getMean(), tol);
-        Assert.assertEquals((10d * 0.5d) / (0.5d * 0.5d), dist.getVariance(), tol);
+        Assertions.assertEquals((10d * 0.5d) / 0.5d, dist.getMean(), tol);
+        Assertions.assertEquals((10d * 0.5d) / (0.5d * 0.5d), dist.getVariance(), tol);
 
         dist = new PascalDistribution(25, 0.7);
-        Assert.assertEquals((25d * 0.3d) / 0.7d, dist.getMean(), tol);
-        Assert.assertEquals((25d * 0.3d) / (0.7d * 0.7d), dist.getVariance(), tol);
+        Assertions.assertEquals((25d * 0.3d) / 0.7d, dist.getMean(), tol);
+        Assertions.assertEquals((25d * 0.3d) / (0.7d * 0.7d), dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PoissonDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PoissonDistributionTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -127,12 +126,12 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
         PoissonDistribution dist = new PoissonDistribution(100);
         double result = dist.normalApproximateProbability(110) -
             dist.normalApproximateProbability(89);
-        Assert.assertEquals(0.706281887248, result, 1e-10);
+        Assertions.assertEquals(0.706281887248, result, 1e-10);
 
         dist = new PoissonDistribution(10000);
         result = dist.normalApproximateProbability(10200) -
             dist.normalApproximateProbability(9899);
-        Assert.assertEquals(0.820070051552, result, 1E-10);
+        Assertions.assertEquals(0.820070051552, result, 1E-10);
     }
 
     /**
@@ -141,8 +140,8 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
     @Test
     public void testDegenerateInverseCumulativeProbability() {
         PoissonDistribution dist = new PoissonDistribution(DEFAULT_TEST_POISSON_PARAMETER);
-        Assert.assertEquals(Integer.MAX_VALUE, dist.inverseCumulativeProbability(1.0d));
-        Assert.assertEquals(0, dist.inverseCumulativeProbability(0d));
+        Assertions.assertEquals(Integer.MAX_VALUE, dist.inverseCumulativeProbability(1.0d));
+        Assertions.assertEquals(0, dist.inverseCumulativeProbability(0d));
     }
 
     @Test
@@ -153,7 +152,7 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
     @Test
     public void testMean() {
         PoissonDistribution dist = new PoissonDistribution(10.0);
-        Assert.assertEquals(10.0, dist.getMean(), 0.0);
+        Assertions.assertEquals(10.0, dist.getMean(), 0.0);
     }
 
     @Test
@@ -169,14 +168,12 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
             while (x >= 0) {
                 try {
                     p = dist.cumulativeProbability((int) x);
-                    Assert.assertFalse("NaN cumulative probability returned for mean = " +
-                            mean + " x = " + x, Double.isNaN(p));
+                    Assertions.assertFalse(Double.isNaN(p), "NaN cumulative probability");
                     if (x > mean - 2 * sigma) {
-                        Assert.assertTrue("Zero cum probaility returned for mean = " +
-                                mean + " x = " + x, p > 0);
+                        Assertions.assertTrue(p > 0, "Zero cumulative probaility");
                     }
                 } catch (AssertionError ex) {
-                    Assert.fail("mean of " + mean + " and x of " + x + " caused " + ex.getMessage());
+                    Assertions.fail("mean of " + mean + " and x of " + x + " caused " + ex.getMessage());
                 }
                 x -= dx;
             }
@@ -201,11 +198,11 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
     }
 
     private void checkProbability(PoissonDistribution dist, int x) {
-        double p = dist.cumulativeProbability(x);
-        Assert.assertFalse("NaN cumulative probability returned for mean = " +
-                dist.getMean() + " x = " + x, Double.isNaN(p));
-        Assert.assertTrue("Zero cum probability returned for mean = " +
-                dist.getMean() + " x = " + x, p > 0);
+        final double p = dist.cumulativeProbability(x);
+        Assertions.assertFalse(Double.isNaN(p), () -> "NaN cumulative probability returned for mean = " +
+                dist.getMean() + " x = " + x);
+        Assertions.assertTrue(p > 0, () -> "Zero cum probability returned for mean = " +
+                dist.getMean() + " x = " + x);
     }
 
     @Test
@@ -219,10 +216,10 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
                 try {
                     int ret = dist.inverseCumulativeProbability(p);
                     // Verify that returned value satisties definition
-                    Assert.assertTrue(p <= dist.cumulativeProbability(ret));
-                    Assert.assertTrue(p > dist.cumulativeProbability(ret - 1));
+                    Assertions.assertTrue(p <= dist.cumulativeProbability(ret));
+                    Assertions.assertTrue(p > dist.cumulativeProbability(ret - 1));
                 } catch (AssertionError ex) {
-                    Assert.fail("mean of " + mean + " and p of " + p + " caused " + ex.getMessage());
+                    Assertions.fail("mean of " + mean + " and p of " + p + " caused " + ex.getMessage());
                 }
                 p += dp;
             }
@@ -236,11 +233,11 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
         PoissonDistribution dist;
 
         dist = new PoissonDistribution(1);
-        Assert.assertEquals(1, dist.getMean(), tol);
-        Assert.assertEquals(1, dist.getVariance(), tol);
+        Assertions.assertEquals(1, dist.getMean(), tol);
+        Assertions.assertEquals(1, dist.getVariance(), tol);
 
         dist = new PoissonDistribution(11.23);
-        Assert.assertEquals(11.23, dist.getMean(), tol);
-        Assert.assertEquals(11.23, dist.getVariance(), tol);
+        Assertions.assertEquals(11.23, dist.getMean(), tol);
+        Assertions.assertEquals(11.23, dist.getVariance(), tol);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PoissonDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PoissonDistributionTest.java
@@ -17,7 +17,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <code>PoissonDistributionTest</code>
@@ -30,10 +32,10 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
      */
     private static final double DEFAULT_TEST_POISSON_PARAMETER = 4.0;
 
-    /**
-     * Constructor.
-     */
-    public PoissonDistributionTest() {
+    // --------------------- Override tolerance  --------------
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-12);
     }
 
@@ -143,9 +145,9 @@ public class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
         Assert.assertEquals(0, dist.inverseCumulativeProbability(0d));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNegativeMean() {
-        new PoissonDistribution(-1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new PoissonDistribution(-1));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TDistributionTest.java
@@ -17,7 +17,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 /**
  * Test cases for TDistribution.
  * Extends ContinuousDistributionAbstractTest.  See class javadoc for
@@ -57,9 +59,9 @@ public class TDistributionTest extends ContinuousDistributionAbstractTest {
     }
 
     // --------------------- Override tolerance  --------------
-    @Override
-    public void setUp() {
-        super.setUp();
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-9);
     }
 
@@ -118,9 +120,9 @@ public class TDistributionTest extends ContinuousDistributionAbstractTest {
         Assert.assertEquals(5d, dist.getDegreesOfFreedom(), Double.MIN_VALUE);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions() {
-        new TDistribution(0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TDistribution(0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TDistributionTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,9 +106,9 @@ public class TDistributionTest extends ContinuousDistributionAbstractTest {
         TDistribution dist;
         for (int i = 1; i < 11; i++) {
             dist = new TDistribution(i * 5);
-            Assert.assertEquals(1,
+            Assertions.assertEquals(1,
                                 dist.cumulativeProbability(Double.POSITIVE_INFINITY), Double.MIN_VALUE);
-            Assert.assertEquals(0,
+            Assertions.assertEquals(0,
                                 dist.cumulativeProbability(Double.NEGATIVE_INFINITY), Double.MIN_VALUE);
         }
     }
@@ -117,7 +116,7 @@ public class TDistributionTest extends ContinuousDistributionAbstractTest {
     @Test
     public void testDfAccessors() {
         TDistribution dist = (TDistribution) getDistribution();
-        Assert.assertEquals(5d, dist.getDegreesOfFreedom(), Double.MIN_VALUE);
+        Assertions.assertEquals(5d, dist.getDegreesOfFreedom(), Double.MIN_VALUE);
     }
 
     @Test
@@ -131,16 +130,16 @@ public class TDistributionTest extends ContinuousDistributionAbstractTest {
         TDistribution dist;
 
         dist = new TDistribution(1);
-        Assert.assertTrue(Double.isNaN(dist.getMean()));
-        Assert.assertTrue(Double.isNaN(dist.getVariance()));
+        Assertions.assertTrue(Double.isNaN(dist.getMean()));
+        Assertions.assertTrue(Double.isNaN(dist.getVariance()));
 
         dist = new TDistribution(1.5);
-        Assert.assertEquals(0, dist.getMean(), tol);
-        Assert.assertTrue(Double.isInfinite(dist.getVariance()));
+        Assertions.assertEquals(0, dist.getMean(), tol);
+        Assertions.assertTrue(Double.isInfinite(dist.getVariance()));
 
         dist = new TDistribution(5);
-        Assert.assertEquals(0, dist.getMean(), tol);
-        Assert.assertEquals(5d / (5d - 2d), dist.getVariance(), tol);
+        Assertions.assertEquals(0, dist.getMean(), tol);
+        Assertions.assertEquals(5d / (5d - 2d), dist.getVariance(), tol);
     }
 
     /*

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TestUtils.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TestUtils.java
@@ -20,7 +20,7 @@ package org.apache.commons.statistics.distribution;
 import java.text.DecimalFormat;
 import org.apache.commons.math3.stat.inference.ChiSquareTest;
 import org.apache.commons.numbers.core.Precision;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Test utilities.
@@ -38,7 +38,7 @@ public final class TestUtils {
     public static void assertEquals(double expected,
                                     double actual,
                                     double delta) {
-        Assert.assertEquals(null, expected, actual, delta);
+        Assertions.assertEquals(expected, actual, delta);
     }
 
     /**
@@ -51,10 +51,9 @@ public final class TestUtils {
                                     double delta) {
         // check for NaN
         if (Double.isNaN(expected)) {
-            Assert.assertTrue("" + actual + " is not NaN.",
-                Double.isNaN(actual));
+            Assertions.assertTrue(Double.isNaN(actual), () -> actual + " is not NaN.");
         } else {
-            Assert.assertEquals(msg, expected, actual, delta);
+            Assertions.assertEquals(expected, actual, delta, msg);
         }
     }
 
@@ -97,16 +96,16 @@ public final class TestUtils {
                                               double actual,
                                               double relativeError) {
         if (Double.isNaN(expected)) {
-            Assert.assertTrue(msg, Double.isNaN(actual));
+            Assertions.assertTrue(Double.isNaN(actual), msg);
         } else if (Double.isNaN(actual)) {
-            Assert.assertTrue(msg, Double.isNaN(expected));
+            Assertions.assertTrue(Double.isNaN(expected), msg);
         } else if (Double.isInfinite(actual) || Double.isInfinite(expected)) {
-            Assert.assertEquals(expected, actual, relativeError);
+            Assertions.assertEquals(expected, actual, relativeError);
         } else if (expected == 0.0) {
-            Assert.assertEquals(msg, actual, expected, relativeError);
+            Assertions.assertEquals(actual, expected, relativeError, msg);
         } else {
             double absError = Math.abs(expected) * relativeError;
-            Assert.assertEquals(msg, expected, actual, absError);
+            Assertions.assertEquals(expected, actual, absError, msg);
         }
     }
 
@@ -122,7 +121,7 @@ public final class TestUtils {
             out.append(expected.length);
             out.append(" observed length = ");
             out.append(observed.length);
-            Assert.fail(out.toString());
+            Assertions.fail(out.toString());
         }
         boolean failure = false;
         for (int i = 0; i < expected.length; i++) {
@@ -138,7 +137,7 @@ public final class TestUtils {
             }
         }
         if (failure) {
-            Assert.fail(out.toString());
+            Assertions.fail(out.toString());
         }
     }
 
@@ -179,7 +178,7 @@ public final class TestUtils {
             msgBuffer.append("This test can fail randomly due to sampling error with probability ");
             msgBuffer.append(alpha);
             msgBuffer.append(".");
-            Assert.fail(msgBuffer.toString());
+            Assertions.fail(msgBuffer.toString());
         }
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TriangularDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TriangularDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@link TriangularDistribution}. See class javadoc for
@@ -26,11 +28,10 @@ import org.junit.Test;
  */
 public class TriangularDistributionTest extends ContinuousDistributionAbstractTest {
 
-    // --- Override tolerance -------------------------------------------------
+    // --------------------- Override tolerance  --------------
 
-    @Override
-    public void setUp() {
-        super.setUp();
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-4);
     }
 
@@ -147,27 +148,27 @@ public class TriangularDistributionTest extends ContinuousDistributionAbstractTe
     }
 
     /** Test pre-condition for equal lower/upper limit. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions1() {
-        new TriangularDistribution(0, 0, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TriangularDistribution(0, 0, 0));
     }
 
     /** Test pre-condition for lower limit larger than upper limit. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions2() {
-        new TriangularDistribution(1, 1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TriangularDistribution(1, 1, 0));
     }
 
     /** Test pre-condition for mode larger than upper limit. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions3() {
-        new TriangularDistribution(0, 2, 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TriangularDistribution(0, 2, 1));
     }
 
     /** Test pre-condition for mode smaller than lower limit. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions4() {
-        new TriangularDistribution(2, 1, 3);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TriangularDistribution(2, 1, 3));
     }
 
     /** Test mean/variance. */

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TriangularDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TriangularDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -137,14 +136,14 @@ public class TriangularDistributionTest extends ContinuousDistributionAbstractTe
     @Test
     public void testGetLowerBound() {
         TriangularDistribution distribution = makeDistribution();
-        Assert.assertEquals(-3.0, distribution.getSupportLowerBound(), 0);
+        Assertions.assertEquals(-3.0, distribution.getSupportLowerBound(), 0);
     }
 
     /** Test upper bound getter. */
     @Test
     public void testGetUpperBound() {
         TriangularDistribution distribution = makeDistribution();
-        Assert.assertEquals(12.0, distribution.getSupportUpperBound(), 0);
+        Assertions.assertEquals(12.0, distribution.getSupportUpperBound(), 0);
     }
 
     /** Test pre-condition for equal lower/upper limit. */
@@ -177,15 +176,15 @@ public class TriangularDistributionTest extends ContinuousDistributionAbstractTe
         TriangularDistribution dist;
 
         dist = new TriangularDistribution(0, 0.5, 1.0);
-        Assert.assertEquals(0.5, dist.getMean(), 0);
-        Assert.assertEquals(1 / 24.0, dist.getVariance(), 0);
+        Assertions.assertEquals(0.5, dist.getMean(), 0);
+        Assertions.assertEquals(1 / 24.0, dist.getVariance(), 0);
 
         dist = new TriangularDistribution(0, 1, 1);
-        Assert.assertEquals(2 / 3.0, dist.getMean(), 0);
-        Assert.assertEquals(1 / 18.0, dist.getVariance(), 0);
+        Assertions.assertEquals(2 / 3.0, dist.getMean(), 0);
+        Assertions.assertEquals(1 / 18.0, dist.getVariance(), 0);
 
         dist = new TriangularDistribution(-3, 2, 12);
-        Assert.assertEquals(3 + (2 / 3.0), dist.getMean(), 0);
-        Assert.assertEquals(175 / 18.0, dist.getVariance(), 0);
+        Assertions.assertEquals(3 + (2 / 3.0), dist.getMean(), 0);
+        Assertions.assertEquals(175 / 18.0, dist.getVariance(), 0);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformContinuousDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformContinuousDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for UniformContinuousDistribution. See class javadoc for
@@ -26,11 +28,10 @@ import org.junit.Test;
  */
 public class UniformContinuousDistributionTest extends ContinuousDistributionAbstractTest {
 
-    // --- Override tolerance -------------------------------------------------
+    // --------------------- Override tolerance  --------------
 
-    @Override
-    public void setUp() {
-        super.setUp();
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-4);
     }
 
@@ -81,15 +82,15 @@ public class UniformContinuousDistributionTest extends ContinuousDistributionAbs
     }
 
     /** Test pre-condition for equal lower/upper bound. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions1() {
-        new UniformContinuousDistribution(0, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new UniformContinuousDistribution(0, 0));
     }
 
     /** Test pre-condition for lower bound larger than upper bound. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions2() {
-        new UniformContinuousDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new UniformContinuousDistribution(1, 0));
     }
 
     /** Test mean/variance. */

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformContinuousDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformContinuousDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,14 +70,14 @@ public class UniformContinuousDistributionTest extends ContinuousDistributionAbs
     @Test
     public void testGetLowerBound() {
         UniformContinuousDistribution distribution = makeDistribution();
-        Assert.assertEquals(-0.5, distribution.getSupportLowerBound(), 0);
+        Assertions.assertEquals(-0.5, distribution.getSupportLowerBound(), 0);
     }
 
     /** Test upper bound getter. */
     @Test
     public void testGetUpperBound() {
         UniformContinuousDistribution distribution = makeDistribution();
-        Assert.assertEquals(1.25, distribution.getSupportUpperBound(), 0);
+        Assertions.assertEquals(1.25, distribution.getSupportUpperBound(), 0);
     }
 
     /** Test pre-condition for equal lower/upper bound. */
@@ -99,16 +98,16 @@ public class UniformContinuousDistributionTest extends ContinuousDistributionAbs
         UniformContinuousDistribution dist;
 
         dist = new UniformContinuousDistribution(0, 1);
-        Assert.assertEquals(0.5, dist.getMean(), 0);
-        Assert.assertEquals(1 / 12.0, dist.getVariance(), 0);
+        Assertions.assertEquals(0.5, dist.getMean(), 0);
+        Assertions.assertEquals(1 / 12.0, dist.getVariance(), 0);
 
         dist = new UniformContinuousDistribution(-1.5, 0.6);
-        Assert.assertEquals(-0.45, dist.getMean(), 0);
-        Assert.assertEquals(0.3675, dist.getVariance(), 0);
+        Assertions.assertEquals(-0.45, dist.getMean(), 0);
+        Assertions.assertEquals(0.3675, dist.getVariance(), 0);
 
         dist = new UniformContinuousDistribution(-0.5, 1.25);
-        Assert.assertEquals(0.375, dist.getMean(), 0);
-        Assert.assertEquals(0.2552083333333333, dist.getVariance(), 0);
+        Assertions.assertEquals(0.375, dist.getMean(), 0);
+        Assertions.assertEquals(0.2552083333333333, dist.getVariance(), 0);
     }
 
     /**
@@ -119,6 +118,6 @@ public class UniformContinuousDistributionTest extends ContinuousDistributionAbs
     public void testInverseCumulativeDistribution() {
         UniformContinuousDistribution dist = new UniformContinuousDistribution(0, 1e-9);
 
-        Assert.assertEquals(2.5e-10, dist.inverseCumulativeProbability(0.25), 0);
+        Assertions.assertEquals(2.5e-10, dist.inverseCumulativeProbability(0.25), 0);
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformDiscreteDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformDiscreteDistributionTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,12 +90,12 @@ public class UniformDiscreteDistributionTest extends DiscreteDistributionAbstrac
         UniformDiscreteDistribution dist;
 
         dist = new UniformDiscreteDistribution(0, 5);
-        Assert.assertEquals(2.5, dist.getMean(), 0);
-        Assert.assertEquals(35 / 12.0, dist.getVariance(), 0);
+        Assertions.assertEquals(2.5, dist.getMean(), 0);
+        Assertions.assertEquals(35 / 12.0, dist.getVariance(), 0);
 
         dist = new UniformDiscreteDistribution(0, 1);
-        Assert.assertEquals(0.5, dist.getMean(), 0);
-        Assert.assertEquals(3 / 12.0, dist.getVariance(), 0);
+        Assertions.assertEquals(0.5, dist.getMean(), 0);
+        Assertions.assertEquals(3 / 12.0, dist.getVariance(), 0);
     }
 
     // MATH-1141
@@ -119,10 +118,10 @@ public class UniformDiscreteDistributionTest extends DiscreteDistributionAbstrac
         UniformDiscreteDistribution dist = new UniformDiscreteDistribution(-hi, hi - 1);
 
         final double tol = Math.ulp(1d);
-        Assert.assertEquals(0.5 / hi, dist.probability(123456), tol);
-        Assert.assertEquals(0.5, dist.cumulativeProbability(-1), tol);
+        Assertions.assertEquals(0.5 / hi, dist.probability(123456), tol);
+        Assertions.assertEquals(0.5, dist.cumulativeProbability(-1), tol);
 
-        Assert.assertTrue(Precision.equals((Math.pow(2d * hi, 2) - 1) / 12, dist.getVariance(), 1));
+        Assertions.assertTrue(Precision.equals((Math.pow(2d * hi, 2) - 1) / 12, dist.getVariance(), 1));
     }
 
     // MATH-1396
@@ -132,9 +131,9 @@ public class UniformDiscreteDistributionTest extends DiscreteDistributionAbstrac
         UniformDiscreteDistribution dist = new UniformDiscreteDistribution(hi - 1, hi + 1);
 
         final double tol = Math.ulp(1d);
-        Assert.assertEquals(1d / 3d, dist.probability(hi), tol);
-        Assert.assertEquals(2d / 3d, dist.cumulativeProbability(hi), tol);
+        Assertions.assertEquals(1d / 3d, dist.probability(hi), tol);
+        Assertions.assertEquals(2d / 3d, dist.cumulativeProbability(hi), tol);
 
-        Assert.assertTrue(Precision.equals(hi, dist.getMean(), 1));
+        Assertions.assertTrue(Precision.equals(hi, dist.getMean(), 1));
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformDiscreteDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/UniformDiscreteDistributionTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.statistics.distribution;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.apache.commons.numbers.core.Precision;
 
 /**
@@ -27,11 +29,10 @@ import org.apache.commons.numbers.core.Precision;
  */
 public class UniformDiscreteDistributionTest extends DiscreteDistributionAbstractTest {
 
-    // --- Override tolerance -------------------------------------------------
+    // --------------------- Override tolerance  --------------
 
-    @Override
-    public void setUp() {
-        super.setUp();
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-9);
     }
 
@@ -99,9 +100,9 @@ public class UniformDiscreteDistributionTest extends DiscreteDistributionAbstrac
     }
 
     // MATH-1141
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditionUpperBoundInclusive1() {
-        new UniformDiscreteDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new UniformDiscreteDistribution(1, 0));
     }
 
     // MATH-1141

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/WeibullDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/WeibullDistributionTest.java
@@ -18,7 +18,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.gamma.LogGamma;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +67,7 @@ public class WeibullDistributionTest extends ContinuousDistributionAbstractTest 
         // Analytically, answer is solution to 1e-17 = 1-exp(-(x/3)^2)
         // x = sqrt(-9*log(1-1e-17))
         // If we're not careful, answer will be 0. Answer below is computed with care in Octave:
-        Assert.assertEquals(9.48683298050514e-9, t, 1e-17);
+        Assertions.assertEquals(9.48683298050514e-9, t, 1e-17);
     }
 
     @Test
@@ -81,7 +80,7 @@ public class WeibullDistributionTest extends ContinuousDistributionAbstractTest 
     @Test
     public void testAlpha() {
         WeibullDistribution dist = new WeibullDistribution(1, 2);
-        Assert.assertEquals(1, dist.getShape(), 0);
+        Assertions.assertEquals(1, dist.getShape(), 0);
     }
     @Test
     public void testPrecondition1() {
@@ -91,7 +90,7 @@ public class WeibullDistributionTest extends ContinuousDistributionAbstractTest 
     @Test
     public void testBeta() {
         WeibullDistribution dist = new WeibullDistribution(1, 2);
-        Assert.assertEquals(2, dist.getScale(), 0);
+        Assertions.assertEquals(2, dist.getScale(), 0);
     }
     @Test
     public void testPrecondition2() {
@@ -105,14 +104,14 @@ public class WeibullDistributionTest extends ContinuousDistributionAbstractTest 
 
         dist = new WeibullDistribution(2.5, 3.5);
         // In R: 3.5*gamma(1+(1/2.5)) (or empirically: mean(rweibull(10000, 2.5, 3.5)))
-        Assert.assertEquals(3.5 * Math.exp(LogGamma.value(1 + (1 / 2.5))), dist.getMean(), tol);
-        Assert.assertEquals((3.5 * 3.5) *
+        Assertions.assertEquals(3.5 * Math.exp(LogGamma.value(1 + (1 / 2.5))), dist.getMean(), tol);
+        Assertions.assertEquals((3.5 * 3.5) *
                             Math.exp(LogGamma.value(1 + (2 / 2.5))) -
                             (dist.getMean() * dist.getMean()), dist.getVariance(), tol);
 
         dist = new WeibullDistribution(10.4, 2.222);
-        Assert.assertEquals(2.222 * Math.exp(LogGamma.value(1 + (1 / 10.4))), dist.getMean(), tol);
-        Assert.assertEquals((2.222 * 2.222) *
+        Assertions.assertEquals(2.222 * Math.exp(LogGamma.value(1 + (1 / 10.4))), dist.getMean(), tol);
+        Assertions.assertEquals((2.222 * 2.222) *
                             Math.exp(LogGamma.value(1 + (2 / 10.4))) -
                             (dist.getMean() * dist.getMean()), dist.getVariance(), tol);
     }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/WeibullDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/WeibullDistributionTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.gamma.LogGamma;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for WeibullDistribution.
@@ -82,9 +83,9 @@ public class WeibullDistributionTest extends ContinuousDistributionAbstractTest 
         WeibullDistribution dist = new WeibullDistribution(1, 2);
         Assert.assertEquals(1, dist.getShape(), 0);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition1() {
-        new WeibullDistribution(0, 2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new WeibullDistribution(0, 2));
     }
 
     @Test
@@ -92,9 +93,9 @@ public class WeibullDistributionTest extends ContinuousDistributionAbstractTest 
         WeibullDistribution dist = new WeibullDistribution(1, 2);
         Assert.assertEquals(2, dist.getScale(), 0);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrecondition2() {
-        new WeibullDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new WeibullDistribution(1, 0));
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ZipfDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ZipfDistributionTest.java
@@ -18,7 +18,6 @@
 package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,8 +114,8 @@ public class ZipfDistributionTest extends DiscreteDistributionAbstractTest {
         ZipfDistribution dist;
 
         dist = new ZipfDistribution(2, 0.5);
-        Assert.assertEquals(Math.sqrt(2), dist.getMean(), tol);
-        Assert.assertEquals(0.24264068711928521, dist.getVariance(), tol);
+        Assertions.assertEquals(Math.sqrt(2), dist.getMean(), tol);
+        Assertions.assertEquals(0.24264068711928521, dist.getVariance(), tol);
     }
 
     /**

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ZipfDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ZipfDistributionTest.java
@@ -19,7 +19,9 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@link ZipfDistribution}.
@@ -28,21 +30,21 @@ import org.junit.Test;
  */
 public class ZipfDistributionTest extends DiscreteDistributionAbstractTest {
 
-    /**
-     * Constructor to override default tolerance.
-     */
-    public ZipfDistributionTest() {
+    // --------------------- Override tolerance  --------------
+
+    @BeforeEach
+    public void customSetUp() {
         setTolerance(1e-12);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions1() {
-        new ZipfDistribution(0, 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ZipfDistribution(0, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPreconditions2() {
-        new ZipfDistribution(1, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ZipfDistribution(1, 0));
     }
 
     //-------------- Implementations for abstract methods -----------------------

--- a/pom.xml
+++ b/pom.xml
@@ -186,16 +186,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
     <statistics.checkstyle.version>3.0.0</statistics.checkstyle.version>
     <statistics.checkstyle.dep.version>8.20</statistics.checkstyle.dep.version>
     <statistics.clirr.version>2.8</statistics.clirr.version>
+    <statistics.junit.bom.version>5.4.2</statistics.junit.bom.version>
     <!-- Workaround to avoid duplicating config files. -->
     <statistics.parent.dir>${basedir}</statistics.parent.dir>
 
@@ -169,14 +170,30 @@
         <artifactId>commons-math3</artifactId>
         <version>${statistics.commons.math3.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${statistics.junit.bom.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
+     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This removes all JUnit 4.

Migration was straight forward:

- Add JUnit 5 Bill-of-materials (BOM) and dependencies to pom to support JUnit 4
- Updated all the test classes to use JUnit 5 annotations
- Switch Assert to Assertions (the order for error messages have to be swapped)
- Remove JUnit 4 support from pom
