### PR TITLE
[STATISTICS-31] Add survivalProbability function for cont. dist.

### DIFF
--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BetaDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BetaDistribution.java
@@ -107,6 +107,18 @@ public class BetaDistribution extends AbstractContinuousDistribution {
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x) {
+        if (x <= 0) {
+            return 1;
+        } else if (x >= 1) {
+            return 0;
+        } else {
+            return RegularizedBeta.value(1 - x, beta, alpha);
+        }
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/CauchyDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/CauchyDistribution.java
@@ -44,7 +44,22 @@ public class CauchyDistribution extends AbstractContinuousDistribution {
     /** {@inheritDoc} */
     @Override
     public double cumulativeProbability(double x) {
-        return 0.5 + (Math.atan((x - median) / scale) / Math.PI);
+        return cdf((x - median) / scale);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x) {
+        return cdf(-(x - median) / scale);
+    }
+
+    /**
+     * Compute the CDF of the Cauchy distribution with location 0 and scale 1.
+     * @param x Point at which the CDF is evaluated
+     * @return CDF(x)
+     */
+    private static double cdf(double x) {
+        return 0.5 + (Math.atan(x) / Math.PI);
     }
 
     /**

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ChiSquaredDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ChiSquaredDistribution.java
@@ -61,6 +61,12 @@ public class ChiSquaredDistribution extends AbstractContinuousDistribution {
         return gamma.cumulativeProbability(x);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x) {
+        return gamma.survivalProbability(x);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ContinuousDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ContinuousDistribution.java
@@ -95,6 +95,23 @@ public interface ContinuousDistribution {
     double cumulativeProbability(double x);
 
     /**
+     * For a random variable {@code X} whose values are distributed according
+     * to this distribution, this method returns {@code P(X > x)}.
+     * In other words, this method represents the complementary cumulative
+     * distribution function.
+     * <p>
+     * By default, this is defined as {@code 1 - cumulativeProbability(x)}, but
+     * the specific implementation may be more accurate.
+     *
+     * @param x Point at which the survival function is evaluated.
+     * @return the probability that a random variable with this
+     * distribution takes a value greater than {@code x}.
+     */
+    default double survivalProbability(double x) {
+        return 1.0 - cumulativeProbability(x);
+    }
+
+    /**
      * Computes the quantile function of this distribution. For a random
      * variable {@code X} distributed according to this distribution, the
      * returned value is

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ExponentialDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ExponentialDistribution.java
@@ -80,7 +80,17 @@ public class ExponentialDistribution extends AbstractContinuousDistribution {
             return 0;
         }
 
-        return 1 - Math.exp(-x / mean);
+        return -Math.expm1(-x / mean);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x)  {
+        if (x <= SUPPORT_LO) {
+            return 1;
+        }
+
+        return Math.exp(-x / mean);
     }
 
     /**

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/FDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/FDistribution.java
@@ -118,6 +118,23 @@ public class FDistribution extends AbstractContinuousDistribution {
                                      0.5 * m);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x)  {
+        if (x <= SUPPORT_LO) {
+            return 1;
+        } else if (x >= SUPPORT_HI) {
+            return 0;
+        }
+
+        final double n = numeratorDegreesOfFreedom;
+        final double m = denominatorDegreesOfFreedom;
+
+        return RegularizedBeta.value(m / (m + n * x),
+                0.5 * m,
+                0.5 * n);
+    }
+
     /**
      * Access the numerator degrees of freedom.
      *

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GammaDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GammaDistribution.java
@@ -255,6 +255,17 @@ public class GammaDistribution extends AbstractContinuousDistribution {
         return RegularizedGamma.P.value(shape, x / scale);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x) {
+        if (x <= SUPPORT_LO) {
+            return 1;
+        } else if (x >= SUPPORT_HI) {
+            return 0;
+        }
+        return RegularizedGamma.Q.value(shape, x / scale);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GumbelDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GumbelDistribution.java
@@ -92,6 +92,13 @@ public class GumbelDistribution extends AbstractContinuousDistribution {
 
     /** {@inheritDoc} */
     @Override
+    public double survivalProbability(double x) {
+        final double z = (x - mu) / beta;
+        return -Math.expm1(-Math.exp(-z));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public double inverseCumulativeProbability(double p) {
         if (p < 0 || p > 1) {
             throw new DistributionException(DistributionException.INVALID_PROBABILITY, p);

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LaplaceDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LaplaceDistribution.java
@@ -80,6 +80,16 @@ public class LaplaceDistribution extends AbstractContinuousDistribution {
 
     /** {@inheritDoc} */
     @Override
+    public double survivalProbability(double x) {
+        if (x <= mu) {
+            return 1.0 - Math.exp((x - mu) / beta) / 2.0;
+        } else {
+            return Math.exp((mu - x) / beta) / 2.0;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public double inverseCumulativeProbability(double p) {
         if (p < 0 ||
             p > 1) {

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LevyDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LevyDistribution.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.statistics.distribution;
 
+import org.apache.commons.numbers.gamma.Erf;
 import org.apache.commons.numbers.gamma.Erfc;
 import org.apache.commons.numbers.gamma.InverseErfc;
 
@@ -98,6 +99,15 @@ public class LevyDistribution extends AbstractContinuousDistribution {
             return 0;
         }
         return Erfc.value(Math.sqrt(halfC / (x - mu)));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(final double x) {
+        if (x < mu) {
+            return 1;
+        }
+        return Erf.value(Math.sqrt(halfC / (x - mu)));
     }
 
     /** {@inheritDoc} */

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LogNormalDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LogNormalDistribution.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.statistics.distribution;
 
-import org.apache.commons.numbers.gamma.Erf;
 import org.apache.commons.numbers.gamma.ErfDifference;
+import org.apache.commons.numbers.gamma.Erfc;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.distribution.LogNormalSampler;
 import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSampler;
@@ -151,7 +151,20 @@ public class LogNormalDistribution extends AbstractContinuousDistribution {
         if (Math.abs(dev) > 40 * shape) {
             return dev < 0 ? 0.0d : 1.0d;
         }
-        return 0.5 + 0.5 * Erf.value(dev / (shape * SQRT2));
+        return 0.5 * Erfc.value(-dev / (shape * SQRT2));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x)  {
+        if (x <= 0) {
+            return 1;
+        }
+        final double dev = Math.log(x) - scale;
+        if (Math.abs(dev) > 40 * shape) {
+            return dev > 0 ? 0.0d : 1.0d;
+        }
+        return 0.5 * Erfc.value(dev / (shape * SQRT2));
     }
 
     /** {@inheritDoc} */

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LogisticDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/LogisticDistribution.java
@@ -92,6 +92,13 @@ public class LogisticDistribution extends AbstractContinuousDistribution {
 
     /** {@inheritDoc} */
     @Override
+    public double survivalProbability(double x) {
+        final double z = oneOverScale * (x - mu);
+        return 1 / (1 + Math.exp(z));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public double inverseCumulativeProbability(double p) {
         if (p < 0 ||
             p > 1) {

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NakagamiDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NakagamiDistribution.java
@@ -100,6 +100,18 @@ public class NakagamiDistribution extends AbstractContinuousDistribution {
 
     /** {@inheritDoc} */
     @Override
+    public double survivalProbability(double x) {
+        if (x <= SUPPORT_LO) {
+            return 1;
+        } else if (x >= SUPPORT_HI) {
+            return 0;
+        }
+
+        return RegularizedGamma.Q.value(mu, mu * x * x / omega);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public double getMean() {
         return Gamma.value(mu + 0.5) / Gamma.value(mu) * Math.sqrt(omega / mu);
     }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NormalDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/NormalDistribution.java
@@ -96,6 +96,16 @@ public class NormalDistribution extends AbstractContinuousDistribution {
 
     /** {@inheritDoc} */
     @Override
+    public double survivalProbability(double x) {
+        final double dev = x - mean;
+        if (Math.abs(dev) > 40 * standardDeviation) {
+            return dev > 0 ? 0.0d : 1.0d;
+        }
+        return 0.5 * Erfc.value(dev / (standardDeviation * SQRT2));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public double inverseCumulativeProbability(final double p) {
         if (p < 0 ||
             p > 1) {

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ParetoDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/ParetoDistribution.java
@@ -126,7 +126,17 @@ public class ParetoDistribution extends AbstractContinuousDistribution {
         if (x <= scale) {
             return 0;
         }
-        return 1 - Math.pow(scale / x, shape);
+        // Can be improved by improving log calculation
+        return -Math.expm1(shape * Math.log(scale / x));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x)  {
+        if (x <= scale) {
+            return 1;
+        }
+        return Math.pow(scale / x, shape);
     }
 
     /**

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/TDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/TDistribution.java
@@ -112,6 +112,12 @@ public class TDistribution extends AbstractContinuousDistribution {
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x) {
+        return cumulativeProbability(-x);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/WeibullDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/WeibullDistribution.java
@@ -126,7 +126,17 @@ public class WeibullDistribution extends AbstractContinuousDistribution {
             return 0;
         }
 
-        return 1 - Math.exp(-Math.pow(x / scale, shape));
+        return -Math.expm1(-Math.pow(x / scale, shape));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(double x) {
+        if (x <= SUPPORT_LO) {
+            return 1;
+        }
+
+        return Math.exp(-Math.pow(x / scale, shape));
     }
 
     /**

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/CauchyDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/CauchyDistributionTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
  */
 class CauchyDistributionTest extends ContinuousDistributionAbstractTest {
 
-    private static final double DEFAULT_TOLERANCE = 1e-7;
+    private static final double DEFAULT_TOLERANCE = 1e-8;
 
     //---------------------- Override tolerance --------------------------------
 
@@ -65,6 +65,28 @@ class CauchyDistributionTest extends ContinuousDistributionAbstractTest {
     public double[] makeDensityTestValues() {
         return new double[] {1.49599158008e-06, 0.000149550440335, 0.000933076881878, 0.00370933207799, 0.0144742330437,
                              1.49599158008e-06, 0.000149550440335, 0.000933076881878, 0.00370933207799, 0.0144742330437};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {-1e16};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {5.551115123125783e-17};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {1e16};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return makeCumulativePrecisionTestValues();
     }
 
     //-------------------- Additional test cases -------------------------------

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ChiSquaredDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ChiSquaredDistributionTest.java
@@ -79,6 +79,28 @@ class ChiSquaredDistributionTest extends ContinuousDistributionAbstractTest {
                              0.000433630076361, 0.00412780610309, 0.00999340341045, 0.0193246438937, 0.0368460089216};
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1e-7, 4e-7, 9e-8};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.6820882879388572e-19, 5.382681944688393e-18, 1.292572946953654e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {93, 97.3};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.5731947657596637e-18, 1.9583114656146269e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ExponentialDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ExponentialDistributionTest.java
@@ -65,6 +65,29 @@ class ExponentialDistributionTest extends ContinuousDistributionAbstractTest {
                              0.00200000000002, 0.00499999999997, 0.00999999999994, 0.0199999999999};
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1e-15, 4e-16, 9e-16};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // calculated via scipy, specifically expon.cdf(x/5).
+        // WolframAlpha provided either too accurate or inaccurate values
+        return new double[] {2.0000000000000002e-16, 7.999999999999999e-17, 1.8000000000000002e-16};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {183, 197};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha. NOTE lambda parameter is 1/mean
+        return new double[] {1.2729811194234181e-16, 7.741006159285781e-18};
+    }
+
     //------------ Additional tests -------------------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/FDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/FDistributionTest.java
@@ -63,6 +63,28 @@ class FDistributionTest extends ContinuousDistributionAbstractTest {
                              0.000133443915657, 0.00286681303403, 0.00969192007502, 0.0242883861471, 0.0605491314658};
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1e-7, 4e-8, 9e-8};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.578691625481747e-17, 1.597523916857153e-18, 1.2131195257872846e-17};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {1e6, 42e5, 63e5};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.1339943867175144e-17, 1.5306104409634358e-19, 4.535143828961954e-20};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GammaDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GammaDistributionTest.java
@@ -73,6 +73,28 @@ class GammaDistributionTest extends ContinuousDistributionAbstractTest {
                              0.000394468852816, 0.00366559696761, 0.00874649473311, 0.0166712508128, 0.0311798227954};
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1e-4, 9e-5};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {2.6040625021701086e-19, 1.7085322417782863e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {99, 103};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {6.833817088979342e-18, 1.0390567840208212e-18};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GumbelDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GumbelDistributionTest.java
@@ -54,6 +54,28 @@ class GumbelDistributionTest extends ContinuousDistributionAbstractTest {
         };
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {-7.0, -7.1};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha, specifically =CDF[ExtremeValueDistribution[0.5, 2], x]
+        return new double[] {3.414512624812977e-19, 3.859421750095851e-20};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {75};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // Not calculated via WolframAlpha, instead utilizing scipy gumbel_r, Wolframalpha could not get precise enough
+        return new double[] {6.64554417291507e-17};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LaplaceDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LaplaceDistributionTest.java
@@ -54,6 +54,30 @@ class LaplaceDistributionTest extends ContinuousDistributionAbstractTest {
         };
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        // Negative values only as anything > 0 falls into an imprecise calculation by being subtracted from 1
+        return new double[] {-42, -43};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {2.87476113214678e-19, 1.0575655187955402e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        // Positive values only as anything < 0 falls into an imprecise calculation by being subtracted from 1
+        return new double[] {42, 43};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {2.87476113214678e-19, 1.0575655187955402e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LevyDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LevyDistributionTest.java
@@ -65,6 +65,28 @@ class LevyDistributionTest extends ContinuousDistributionAbstractTest {
             -2.650679030597d, -3.644945255983d};
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1.205, 1.2049};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {3.7440973842063723e-19, 1.6388396909072308e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {1e39, 42e37};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.5957691216057308e-20, 2.4623252122982907e-20};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogNormalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogNormalDistributionTest.java
@@ -32,7 +32,7 @@ class LogNormalDistributionTest extends ContinuousDistributionAbstractTest {
 
     @BeforeEach
     void customSetUp() {
-        setTolerance(1e-7);
+        setTolerance(1e-10);
     }
 
     //-------------- Implementations for abstract methods ----------------------
@@ -102,6 +102,28 @@ class LogNormalDistributionTest extends ContinuousDistributionAbstractTest {
         //return Arrays.copyOfRange(points, 1, points.length - 4);
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {4e-5, 7e-5};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.2366527173500762e-18, 3.9216120913158885e-17};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {999999, 2e6};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {2.924727705260493e-17, 3.8830698713006447e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     private void verifyQuantiles() {
@@ -166,6 +188,15 @@ class LogNormalDistributionTest extends ContinuousDistributionAbstractTest {
         setCumulativeTestPoints(new double[] {0.5, 10});
         setCumulativeTestValues(new double[] {0, 1.0});
         verifyCumulativeProbabilities();
+    }
+
+    @Test
+    void testSurvivalProbabilityExtremes() {
+        // Use a small shape parameter so that we can exceed 40 * shape
+        setDistribution(new LogNormalDistribution(1, 0.0001));
+        setCumulativeTestPoints(new double[] {0.5, 10});
+        setCumulativeTestValues(new double[] {0, 1.0});
+        verifySurvivalProbability();
     }
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogisticsDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/LogisticsDistributionTest.java
@@ -54,6 +54,28 @@ class LogisticsDistributionTest extends ContinuousDistributionAbstractTest {
         };
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {-197, -203};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {5.188951605054656e-18, 1.5628821893349888e-18};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {197, 203};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {1.1548224173015786e-17, 3.478258278776922e-18};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NakagamiDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NakagamiDistributionTest.java
@@ -54,6 +54,28 @@ class NakagamiDistributionTest extends ContinuousDistributionAbstractTest {
         };
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1e-16, 4e-17};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {7.978845608028653e-17, 3.1915382432114614e-17};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {9, 8.7};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {2.2571768119076845e-19, 3.318841739929575e-18};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NormalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/NormalDistributionTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
  */
 class NormalDistributionTest extends ContinuousDistributionAbstractTest {
 
-    private static final double DEFAULT_TOLERANCE = 1e-7;
+    private static final double DEFAULT_TOLERANCE = 1e-10;
 
     //---------------------- Override tolerance --------------------------------
 
@@ -65,6 +65,28 @@ class NormalDistributionTest extends ContinuousDistributionAbstractTest {
     public double[] makeDensityTestValues() {
         return new double[] {0.00240506434076, 0.0190372444310, 0.0417464784322, 0.0736683145538, 0.125355951380,
                              0.00240506434076, 0.0190372444310, 0.0417464784322, 0.0736683145538, 0.125355951380};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {-10, -10.3};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {2.741222634611109e-18, 4.1045652533919113e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {14.5, 13.9};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {4.1045652533919576e-19, 1.749552800697539e-17};
     }
 
     //-------------------- Additional test cases -------------------------------

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ParetoDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/ParetoDistributionTest.java
@@ -31,7 +31,7 @@ class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
 
     @BeforeEach
     void customSetUp() {
-        setTolerance(1e-7);
+        setTolerance(1e-9);
     }
 
     //-------------- Implementations for abstract methods ----------------------
@@ -88,6 +88,28 @@ class ParetoDistributionTest extends ContinuousDistributionAbstractTest {
         final double[] points2 = new double[points.length - 5];
         System.arraycopy(points, 5, points2, 0, points.length - 5);
         return points2;
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {2.100000000000001, 2.100000000000005};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were not created using WolframAlpha, the calculation for Math.log underflows in java
+        return new double[] {6.217248937900875e-16, 3.2640556923979585e-15};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {42e11, 64e11};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {6.005622169907148e-18, 3.330082930386111e-18};
     }
 
     //-------------------- Additional test cases -------------------------------

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/TDistributionTest.java
@@ -63,6 +63,28 @@ class TDistributionTest extends ContinuousDistributionAbstractTest {
                              0.000756494565517, 0.0109109752919, 0.0303377878006, 0.0637967988952, 0.128289492005};
     }
 
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {-4200, -6400};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {7.261513520181652e-18, 8.838404680725267e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {4200, 6400};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {7.261513520181652e-18, 8.838404680725267e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     /**

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/WeibullDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/WeibullDistributionTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.statistics.distribution;
 
 import org.apache.commons.numbers.gamma.LogGamma;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,6 +28,11 @@ import org.junit.jupiter.api.Test;
  * ContinuousDistributionAbstractTest for details.
  */
 class WeibullDistributionTest extends ContinuousDistributionAbstractTest {
+
+    @BeforeEach
+    void customSetUp() {
+        setTolerance(1e-10);
+    }
 
     //-------------- Implementations for abstract methods ----------------------
 
@@ -55,6 +61,28 @@ class WeibullDistributionTest extends ContinuousDistributionAbstractTest {
     public double[] makeDensityTestValues() {
         return new double[] {0.180535929306, 0.262801138133, 0.301905425199, 0.330899152971,
                              0.353441418887, 0.000788590320203, 0.00737060094841, 0.0177576041516, 0.0343043442574, 0.065664589369};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestPoints() {
+        return new double[] {1e-14, 1e-15};
+    }
+
+    @Override
+    public double[] makeCumulativePrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {6.506341377907031e-18, 4.1052238780858223e-19};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestPoints() {
+        return new double[] {45, 47.2};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // These were created using WolframAlpha
+        return new double[] {6.6352694710268576e-18, 6.444810903667567e-19};
     }
 
     //-------------------- Additional test cases -------------------------------


### PR DESCRIPTION
This commit adds a new function for all continuous
distributions `survivalProbability`.

While a naive implementation would simply be
`1-cumulativeProbability`, that would result
in loss of precision.

For many of the current cont. dist. a higher
precision survival probability is calculated

For others, it is simply `1-cumulativeProbability`

Many tests were added to verify the following:
- the precision of cumulativeProbability
- the precision of survivalProbability
- That survivalProbabiliy is near 1-cumulative
- That survival and cumulative probabilities are
  complementary

Through this development, certain distributions
were found lacking precision for their
cumulativeProbabilities and were improved.

Those were:

- CauchyDistribution
- ExponentialDistribution
- LogNormalDistribution
- PretoDistribution
- WeibullDistribution

Addresses Jira: STATISTICS-31