### PR TITLE
STATISTICS-32: New "survivalProbability" function for all discrete distributions

### DIFF
--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BinomialDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/BinomialDistribution.java
@@ -101,8 +101,24 @@ public class BinomialDistribution extends AbstractDiscreteDistribution {
         } else if (x >= numberOfTrials) {
             ret = 1.0;
         } else {
-            ret = 1.0 - RegularizedBeta.value(probabilityOfSuccess,
-                                              x + 1.0, (double) numberOfTrials - x);
+            // Use a helper function to compute the complement of the survival probability
+            ret = RegularizedBetaUtils.complement(probabilityOfSuccess,
+                                                  x + 1.0, (double) numberOfTrials - x);
+        }
+        return ret;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(int x) {
+        double ret;
+        if (x < 0) {
+            ret = 1.0;
+        } else if (x >= numberOfTrials) {
+            ret = 0.0;
+        } else {
+            ret = RegularizedBeta.value(probabilityOfSuccess,
+                                        x + 1.0, (double) numberOfTrials - x);
         }
         return ret;
     }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/DiscreteDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/DiscreteDistribution.java
@@ -73,6 +73,23 @@ public interface DiscreteDistribution {
     double cumulativeProbability(int x);
 
     /**
+     * For a random variable {@code X} whose values are distributed according
+     * to this distribution, this method returns {@code P(X > x)}.
+     * In other words, this method represents the complementary cumulative
+     * distribution function.
+     * <p>
+     * By default, this is defined as {@code 1 - cumulativeProbability(x)}, but
+     * the specific implementation may be more accurate.
+     *
+     * @param x Point at which the survival function is evaluated.
+     * @return the probability that a random variable with this
+     * distribution takes a value greater than {@code x}.
+     */
+    default double survivalProbability(int x) {
+        return 1.0 - cumulativeProbability(x);
+    }
+
+    /**
      * Computes the quantile function of this distribution.
      * For a random variable {@code X} distributed according to this distribution,
      * the returned value is

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GeometricDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/GeometricDistribution.java
@@ -79,6 +79,15 @@ public class GeometricDistribution extends AbstractDiscreteDistribution {
         return -Math.expm1(log1mProbabilityOfSuccess * (x + 1));
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(int x) {
+        if (x < 0) {
+            return 1.0;
+        }
+        return Math.exp(log1mProbabilityOfSuccess * (x + 1));
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PascalDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PascalDistribution.java
@@ -108,6 +108,9 @@ public class PascalDistribution extends AbstractDiscreteDistribution {
         double ret;
         if (x < 0) {
             ret = 0.0;
+        } else if (x == 0) {
+            // Special case exploiting cancellation.
+            ret = Math.pow(probabilityOfSuccess, numberOfSuccesses);
         } else {
             ret = BinomialCoefficientDouble.value(x +
                   numberOfSuccesses - 1, numberOfSuccesses - 1) *
@@ -123,6 +126,9 @@ public class PascalDistribution extends AbstractDiscreteDistribution {
         double ret;
         if (x < 0) {
             ret = Double.NEGATIVE_INFINITY;
+        } else if (x == 0) {
+            // Special case exploiting cancellation.
+            ret = logProbabilityOfSuccess * numberOfSuccesses;
         } else {
             ret = LogBinomialCoefficient.value(x +
                   numberOfSuccesses - 1, numberOfSuccesses - 1) +
@@ -141,6 +147,20 @@ public class PascalDistribution extends AbstractDiscreteDistribution {
         } else {
             ret = RegularizedBeta.value(probabilityOfSuccess,
                                         numberOfSuccesses, x + 1.0);
+        }
+        return ret;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(int x) {
+        double ret;
+        if (x < 0) {
+            ret = 1.0;
+        } else {
+            // Use a helper function to compute the complement of the cumulative probability
+            ret = RegularizedBetaUtils.complement(probabilityOfSuccess,
+                                                  numberOfSuccesses, x + 1.0);
         }
         return ret;
     }

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PoissonDistribution.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/PoissonDistribution.java
@@ -108,6 +108,19 @@ public class PoissonDistribution extends AbstractDiscreteDistribution {
                                         maxIterations);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public double survivalProbability(int x) {
+        if (x < 0) {
+            return 1;
+        }
+        if (x == Integer.MAX_VALUE) {
+            return 0;
+        }
+        return RegularizedGamma.P.value((double) x + 1, mean, epsilon,
+                                        maxIterations);
+    }
+
     /**
      * Calculates the Poisson distribution function using a normal
      * approximation. The {@code N(mean, sqrt(mean))} distribution is used

--- a/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/RegularizedBetaUtils.java
+++ b/commons-statistics-distribution/src/main/java/org/apache/commons/statistics/distribution/RegularizedBetaUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.distribution;
+
+import org.apache.commons.numbers.gamma.RegularizedBeta;
+
+/**
+ * Utilities for the <a href="http://mathworld.wolfram.com/RegularizedBetaFunction.html">
+ * Regularized Beta function</a> {@code I(x, a, b)}.
+ */
+final class RegularizedBetaUtils {
+    /** No instances. */
+    private RegularizedBetaUtils() {}
+
+    /**
+     * Compute the complement of the regularized beta function {@code I(x, a, b)}.
+     * <pre>
+     * 1 - I(x, a, b) = I(1 - x, b, a)
+     * </pre>
+     *
+     * @param x the value.
+     * @param a Parameter {@code a}.
+     * @param b Parameter {@code b}.
+     * @return the complement of the regularized beta function 1 - I(x, a, b).
+     */
+    static double complement(double x, double a, double b) {
+        // Identity of the regularized beta function: 1 - I_z(a, b) = I_{1-x}(b, a)
+        // Ideally call RegularizedBeta.value(1 - x, b, a) to maximise precision.
+        //
+        // The implementation of the beta function will use the complement based on a condition.
+        // Here we repeat the condition with a and b switched and testing 1 - x.
+        // This will avoid double inversion of the parameters.
+        final double mxp1 = 1 - x;
+        if (mxp1 > (b + 1) / (2 + b + a)) {
+            // Note: This drops the addition test '&& x <= (a + 1) / (2 + b + a)'
+            // The test is to avoid infinite method call recursion which does not apply
+            // in this case. See MATH-1067.
+
+            // Direct computation of the complement with the input x.
+            // Avoids loss of precision when x != 1 - (1-x)
+            return 1.0 - RegularizedBeta.value(x, a, b);
+        }
+        // Use the identity which should be computed directly by the RegularizedBeta implementation.
+        return RegularizedBeta.value(mxp1, b, a);
+    }
+}

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BinomialDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/BinomialDistributionTest.java
@@ -78,6 +78,29 @@ class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
 
     //-------------------- Additional test cases -------------------------------
 
+    /** Test case n = 10, p = 0.3. */
+    @Test
+    void testSmallPValue() {
+        final BinomialDistribution dist = new BinomialDistribution(10, 0.3);
+        setDistribution(dist);
+        // computed using R version 3.4.4
+        setCumulativeTestValues(new double[] {0.00000000000000000000, 0.02824752489999998728, 0.14930834590000002793,
+            0.38278278639999974153, 0.64961071840000017552, 0.84973166740000016794, 0.95265101260000006889,
+            0.98940792160000001765, 0.99840961360000002323, 0.99985631409999997654, 0.99999409509999992451,
+            1.00000000000000000000, 1.00000000000000000000});
+        setDensityTestValues(new double[] {0.0000000000000000000e+00, 2.8247524899999980341e-02,
+            1.2106082099999991575e-01, 2.3347444049999999116e-01, 2.6682793199999993439e-01, 2.0012094900000007569e-01,
+            1.0291934520000002584e-01, 3.6756909000000004273e-02, 9.0016919999999864960e-03, 1.4467005000000008035e-03,
+            1.3778099999999990615e-04, 5.9048999999999949131e-06, 0.0000000000000000000e+00});
+        setInverseCumulativeTestValues(new int[] {0, 0, 0, 0, 1, 1, 8, 7, 6, 5, 5, 10});
+        verifyDensities();
+        verifyLogDensities();
+        verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
+        verifyInverseCumulativeProbabilities();
+    }
+
     /** Test degenerate case p = 0 */
     @Test
     void testDegenerate0() {
@@ -90,7 +113,10 @@ class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {0, 0});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
         Assertions.assertEquals(0, dist.getSupportLowerBound());
         Assertions.assertEquals(0, dist.getSupportUpperBound());
@@ -108,7 +134,10 @@ class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {5, 5});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
         Assertions.assertEquals(5, dist.getSupportLowerBound());
         Assertions.assertEquals(5, dist.getSupportUpperBound());
@@ -126,7 +155,10 @@ class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {0, 0});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
         Assertions.assertEquals(0, dist.getSupportLowerBound());
         Assertions.assertEquals(0, dist.getSupportUpperBound());
@@ -183,5 +215,23 @@ class BinomialDistributionTest extends DiscreteDistributionAbstractTest {
             final int p = dist.inverseCumulativeProbability(0.5);
             Assertions.assertEquals(trials / 2, p);
         }
+    }
+
+    @Test
+    void testHighPrecisionCumulativeProbabilities() {
+        // computed using R version 3.4.4
+        setDistribution(new BinomialDistribution(100, 0.99));
+        setCumulativePrecisionTestPoints(new int[] {82, 81});
+        setCumulativePrecisionTestValues(new double[] {1.4061271955993513664e-17, 6.1128083336354843707e-19});
+        verifyCumulativeProbabilityPrecision();
+    }
+
+    @Test
+    void testHighPrecisionSurvivalProbabilities() {
+        // computed using R version 3.4.4
+        setDistribution(new BinomialDistribution(100, 0.01));
+        setSurvivalPrecisionTestPoints(new int[] {18, 19});
+        setSurvivalPrecisionTestValues(new double[] {6.1128083336353977038e-19, 2.4944165604029235392e-20});
+        verifySurvivalProbabilityPrecision();
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/DiscreteDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/DiscreteDistributionTest.java
@@ -40,7 +40,11 @@ class DiscreteDistributionTest {
             }
             @Override
             public double cumulativeProbability(int x) {
-                return 0;
+                // Return some different values to allow the survival probability to be tested
+                if (x < 0) {
+                    return x < -5 ? 0.25 : 0.5;
+                }
+                return x > 5 ? 1.0 : 0.75;
             }
             @Override
             public int inverseCumulativeProbability(double p) {
@@ -75,6 +79,8 @@ class DiscreteDistributionTest {
         for (final int x : new int[] {Integer.MIN_VALUE, -1, 0, 1, 2, Integer.MAX_VALUE}) {
             // Return the log of the density
             Assertions.assertEquals(Math.log(x), dist.logProbability(x));
+            // Must return 1 - CDF(x)
+            Assertions.assertEquals(1.0 - dist.cumulativeProbability(x), dist.survivalProbability(x));
         }
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GeometricDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/GeometricDistributionTest.java
@@ -138,6 +138,17 @@ class GeometricDistributionTest extends DiscreteDistributionAbstractTest {
         };
     }
 
+    @Override
+    public int[] makeSurvivalPrecisionTestPoints() {
+        return new int[] {74, 81};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // computed using R version 3.4.4
+        return new double[] {2.2979669527522718895e-17, 6.4328367688565960968e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     @Test

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/HypergeometricDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/HypergeometricDistributionTest.java
@@ -101,7 +101,10 @@ class HypergeometricDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {3, 3});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
         Assertions.assertEquals(3, dist.getSupportLowerBound());
         Assertions.assertEquals(3, dist.getSupportUpperBound());
@@ -119,7 +122,10 @@ class HypergeometricDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {0, 0});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
         Assertions.assertEquals(0, dist.getSupportLowerBound());
         Assertions.assertEquals(0, dist.getSupportUpperBound());
@@ -137,7 +143,10 @@ class HypergeometricDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {3, 3});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
         Assertions.assertEquals(3, dist.getSupportLowerBound());
         Assertions.assertEquals(3, dist.getSupportUpperBound());
@@ -320,5 +329,23 @@ class HypergeometricDistributionTest extends DiscreteDistributionAbstractTest {
             Assertions.assertTrue(0 <= sample, () -> "sample=" + sample);
             Assertions.assertTrue(sample <= n, () -> "sample=" + sample);
         }
+    }
+
+    @Test
+    void testHighPrecisionCumulativeProbabilities() {
+        // computed using R version 3.4.4
+        setDistribution(new HypergeometricDistribution(500, 70, 300));
+        setCumulativePrecisionTestPoints(new int[] {10, 8});
+        setCumulativePrecisionTestValues(new double[] {2.4055720603264525e-17, 1.2848174992266236e-19});
+        verifySurvivalProbabilityPrecision();
+    }
+
+    @Test
+    void testHighPrecisionSurvivalProbabilities() {
+        // computed using R version 3.4.4
+        setDistribution(new HypergeometricDistribution(500, 70, 300));
+        setSurvivalPrecisionTestPoints(new int[] {68, 69});
+        setSurvivalPrecisionTestValues(new double[] {4.570379934029859e-16, 7.4187180434325268e-18});
+        verifySurvivalProbabilityPrecision();
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PascalDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PascalDistributionTest.java
@@ -78,6 +78,17 @@ class PascalDistributionTest extends DiscreteDistributionAbstractTest {
         return new int[] {0, 0, 0, 0, 1, 1, 14, 11, 10, 9, 8, Integer.MAX_VALUE};
     }
 
+    @Override
+    public int[] makeSurvivalPrecisionTestPoints() {
+        return new int[] {47, 52};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // computed using R version 3.4.4
+        return new double[] {3.1403888119656772712e-17, 1.7075879020163069251e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     /** Test degenerate case p = 0   */
@@ -91,7 +102,10 @@ class PascalDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {Integer.MAX_VALUE, Integer.MAX_VALUE});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
     }
 
@@ -106,7 +120,10 @@ class PascalDistributionTest extends DiscreteDistributionAbstractTest {
         setInverseCumulativeTestPoints(new double[] {0.1d, 0.5d});
         setInverseCumulativeTestValues(new int[] {0, 0});
         verifyDensities();
+        verifyLogDensities();
         verifyCumulativeProbabilities();
+        verifySurvivalProbability();
+        verifySurvivalAndCumulativeProbabilityComplement();
         verifyInverseCumulativeProbabilities();
     }
 

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PoissonDistributionTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/PoissonDistributionTest.java
@@ -95,6 +95,17 @@ class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
         return new int[] {0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 10, 20};
     }
 
+    @Override
+    public int[] makeSurvivalPrecisionTestPoints() {
+        return new int[] {30, 32};
+    }
+
+    @Override
+    public double[] makeSurvivalPrecisionTestValues() {
+        // computed using R version 3.4.4
+        return new double[] {1.1732435431464340474e-17, 1.7630174687875970627e-19};
+    }
+
     //-------------------- Additional test cases -------------------------------
 
     /**
@@ -220,5 +231,14 @@ class PoissonDistributionTest extends DiscreteDistributionAbstractTest {
             }
             mean *= 10.0;
         }
+    }
+
+    @Test
+    void testLargeMeanHighPrecisionCumulativeProbabilities() {
+        // computed using R version 3.4.4
+        setDistribution(new PoissonDistribution(100));
+        setCumulativePrecisionTestPoints(new int[] {28, 25});
+        setCumulativePrecisionTestValues(new double[] {1.6858675763053070496e-17, 3.184075559619425735e-19});
+        verifyCumulativeProbabilityPrecision();
     }
 }

--- a/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/RegularizedBetaUtilsTest.java
+++ b/commons-statistics-distribution/src/test/java/org/apache/commons/statistics/distribution/RegularizedBetaUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.distribution;
+
+import org.apache.commons.numbers.gamma.RegularizedBeta;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link RegularizedBetaUtils}.
+ */
+class RegularizedBetaUtilsTest {
+    @Test
+    void testComplement() {
+        final double[] xs = {0, 0.1, 0.2, 0.25, 0.3, 1.0 / 3, 0.4, 0.5, 0.6, 2.0 / 3, 0.7, 0.75, 0.8, 0.9, 1};
+        // Called in PascalDistribution with a >= 1; b >= 1
+        // Called in BinomialDistribution with a >= 1; b >= 1
+        final double[] as = {1, 2, 3, 4, 5, 10, 20, 100, 1000};
+        final double[] bs = {1, 2, 3, 4, 5, 10, 20, 100, 1000};
+        for (final double x : xs) {
+            for (final double a : as) {
+                for (final double b : bs) {
+                    assertComplement(x, a, b);
+                }
+            }
+        }
+    }
+
+    private static void assertComplement(double x, double a, double b) {
+        final double expected1 = 1.0 - RegularizedBeta.value(x, a, b);
+        final double expected2 = RegularizedBeta.value(1 - x, b, a);
+        final double actual = RegularizedBetaUtils.complement(x, a, b);
+        // Expect binary equality with 1 result
+        Assertions.assertTrue(expected1 == actual || expected2 == actual,
+            () -> String.format("I(%s, %s, %s) Expected %s or %s: Actual %s", x, a, b, expected1, expected2, actual));
+    }
+}


### PR DESCRIPTION
While a naive implementation would simply be
`1-cumulativeProbability`, that would result
in loss of precision.

For many of the current discrete distributions a higher
precision survival probability is calculated.

For others, it is simply `1-cumulativeProbability`.

Many tests were added to verify the following:
- the precision of cumulativeProbability
- the precision of survivalProbability
- That survivalProbabiliy is near 1-cumulative
- That survival and cumulative probabilities are
  complementary

Through this development, certain distributions
were found lacking precision for their
cumulativeProbabilities and were improved.

These were:

- BinomialDistribution

Expanding the tests for the Pascal distribution for the degenerate cases
found a bug in the p=1 degenerate case when x=0. The NaN return value
has been corrected to either 0 (x=0) or -infinity (x!=0).