### PR TITLE
STATISTICS-69: Add an unconditioned exact test for 2x2 tables

### DIFF
--- a/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/Arguments.java
+++ b/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/Arguments.java
@@ -100,7 +100,7 @@ final class Arguments {
     }
 
     /**
-     * Check that all values are {@code > 0}.
+     * Check that value is {@code > 0}.
      *
      * @param v Value to be tested.
      * @return the value
@@ -111,6 +111,21 @@ final class Arguments {
             throw new InferenceException(InferenceException.NOT_STRICTLY_POSITIVE, v);
         }
         return v;
+    }
+
+    /**
+     * Check that value is {@code > 0}.
+     *
+     * @param v Value to be tested.
+     * @return the value
+     * @throws IllegalArgumentException if the value is not strictly positive.
+     */
+    static double checkStrictlyPositive(double v) {
+        if (v > 0) {
+            return v;
+        }
+        // not positive or NaN
+        throw new InferenceException(InferenceException.NOT_STRICTLY_POSITIVE, v);
     }
 
     /**

--- a/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/BracketFinder.java
+++ b/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/BracketFinder.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import java.util.function.DoubleUnaryOperator;
+
+/**
+ * Provide an interval that brackets a local minimum of a function.
+ * This code is based on a Python implementation (from <em>SciPy</em>,
+ * module {@code optimize.py} v0.5).
+ *
+ * <p>This class has been extracted from {@code o.a.c.math4.optim.univariate}
+ * and modified to: remove support for bracketing a maximum; support bounds
+ * on the bracket; correct the sign of the denominator when the magnitude is small;
+ * and return true/false if there is a minimum strictly inside the bounds.
+ *
+ * @since 1.1
+ */
+class BracketFinder {
+    /** Tolerance to avoid division by zero. */
+    private static final double EPS_MIN = 1e-21;
+    /** Golden section. */
+    private static final double GOLD = 1.6180339887498948482;
+    /** Factor for expanding the interval. */
+    private final double growLimit;
+    /**  Number of allowed function evaluations. */
+    private final int maxEvaluations;
+    /** Number of function evaluations performed in the last search. */
+    private int evaluations;
+    /** Lower bound of the bracket. */
+    private double lo;
+    /** Higher bound of the bracket. */
+    private double hi;
+    /** Point inside the bracket. */
+    private double mid;
+    /** Function value at {@link #lo}. */
+    private double fLo;
+    /** Function value at {@link #hi}. */
+    private double fHi;
+    /** Function value at {@link #mid}. */
+    private double fMid;
+
+    /**
+     * Constructor with default values {@code 100, 100000} (see the
+     * {@link #BracketFinder(double,int) other constructor}).
+     */
+    BracketFinder() {
+        this(100, 100000);
+    }
+
+    /**
+     * Create a bracketing interval finder.
+     *
+     * @param growLimit Expanding factor.
+     * @param maxEvaluations Maximum number of evaluations allowed for finding
+     * a bracketing interval.
+     * @throws IllegalArgumentException if the {@code growLimit} or {@code maxEvalutations}
+     * are not strictly positive.
+     */
+    BracketFinder(double growLimit, int maxEvaluations) {
+        Arguments.checkStrictlyPositive(growLimit);
+        Arguments.checkStrictlyPositive(maxEvaluations);
+        this.growLimit = growLimit;
+        this.maxEvaluations = maxEvaluations;
+    }
+
+    /**
+     * Search downhill from the initial points to obtain new points that bracket a local
+     * minimum of the function. Note that the initial points do not have to bracket a minimum.
+     * An exception is raised if a minimum cannot be found within the configured number
+     * of function evaluations.
+     *
+     * <p>The bracket is limited to the provided bounds if they create a positive interval
+     * {@code min < max}. It is possible that the middle of the bracket is at the bounds as
+     * the final bracket is {@code f(mid) <= min(f(lo), f(hi))} and {@code lo <= mid <= hi}.
+     *
+     * <p>No exception is raised if the initial points are not within the bounds; the points
+     * are updated to be within the bounds.
+     *
+     * <p>No exception is raised if the initial points are equal; the bracket will be returned
+     * as a single point {@code lo == mid == hi}.
+     *
+     * @param func Function whose optimum should be bracketed.
+     * @param a Initial point.
+     * @param b Initial point.
+     * @param min Minimum bound of the bracket (inclusive).
+     * @param max Maximum bound of the bracket (inclusive).
+     * @return true if the mid-point is strictly within the final bracket {@code [lo, hi]};
+     * false if there is no local minima.
+     * @throws IllegalStateException if the maximum number of evaluations is exceeded.
+     */
+    boolean search(DoubleUnaryOperator func,
+                   double a, double b,
+                   double min, double max) {
+        evaluations = 0;
+
+        // Limit the range of x
+        DoubleUnaryOperator range;
+        if (min < max) {
+            // Limit: min <= x <= max
+            range = x -> {
+                if (x > min) {
+                    return x < max ? x : max;
+                }
+                return min;
+            };
+        } else {
+            range = DoubleUnaryOperator.identity();
+        }
+
+        double xA = range.applyAsDouble(a);
+        double xB = range.applyAsDouble(b);
+        double fA = value(func, xA);
+        double fB = value(func, xB);
+        // Ensure fB <= fA
+        if (fA < fB) {
+            double tmp = xA;
+            xA = xB;
+            xB = tmp;
+            tmp = fA;
+            fA = fB;
+            fB = tmp;
+        }
+
+        double xC = range.applyAsDouble(xB + GOLD * (xB - xA));
+        double fC = value(func, xC);
+
+        // Note: When a [min, max] interval is provided and there is no minima then this
+        // loop will terminate when B == C and both are at the min/max bound.
+        while (fC < fB) {
+            final double tmp1 = (xB - xA) * (fB - fC);
+            final double tmp2 = (xB - xC) * (fB - fA);
+
+            final double val = tmp2 - tmp1;
+            // limit magnitude of val to a small value
+            final double denom = 2 * Math.copySign(Math.max(Math.abs(val), EPS_MIN), val);
+
+            double w = range.applyAsDouble(xB - ((xB - xC) * tmp2 - (xB - xA) * tmp1) / denom);
+            final double wLim = range.applyAsDouble(xB + growLimit * (xC - xB));
+
+            double fW;
+            if ((w - xC) * (xB - w) > 0) {
+                // xB < w < xC
+                fW = value(func, w);
+                if (fW < fC) {
+                    // minimum in [xB, xC]
+                    xA = xB;
+                    xB = w;
+                    fA = fB;
+                    fB = fW;
+                    break;
+                } else if (fW > fB) {
+                    // minimum in [xA, w]
+                    xC = w;
+                    fC = fW;
+                    break;
+                }
+                // continue downhill
+                w = range.applyAsDouble(xC + GOLD * (xC - xB));
+                fW = value(func, w);
+            } else if ((w - wLim) * (xC - w) > 0) {
+                // xC < w < limit
+                fW = value(func, w);
+                if (fW < fC) {
+                    // continue downhill
+                    xB = xC;
+                    xC = w;
+                    w = range.applyAsDouble(xC + GOLD * (xC - xB));
+                    fB = fC;
+                    fC = fW;
+                    fW = value(func, w);
+                }
+            } else if ((w - wLim) * (wLim - xC) >= 0) {
+                // xC <= limit <= w
+                w = wLim;
+                fW = value(func, w);
+            } else {
+                // possibly w == xC; reject w and take a default step
+                w = range.applyAsDouble(xC + GOLD * (xC - xB));
+                fW = value(func, w);
+            }
+
+            xA = xB;
+            fA = fB;
+            xB = xC;
+            fB = fC;
+            xC = w;
+            fC = fW;
+        }
+
+        mid = xB;
+        fMid = fB;
+
+        // Store the bracket: lo <= mid <= hi
+        if (xC < xA) {
+            lo = xC;
+            fLo = fC;
+            hi = xA;
+            fHi = fA;
+        } else {
+            lo = xA;
+            fLo = fA;
+            hi = xC;
+            fHi = fC;
+        }
+
+        return lo < mid && mid < hi;
+    }
+
+    /**
+     * @return the number of evaluations.
+     */
+    int getEvaluations() {
+        return evaluations;
+    }
+
+    /**
+     * @return the lower bound of the bracket.
+     * @see #getFLo()
+     */
+    double getLo() {
+        return lo;
+    }
+
+    /**
+     * Get function value at {@link #getLo()}.
+     * @return function value at {@link #getLo()}
+     */
+    double getFLo() {
+        return fLo;
+    }
+
+    /**
+     * @return the higher bound of the bracket.
+     * @see #getFHi()
+     */
+    double getHi() {
+        return hi;
+    }
+
+    /**
+     * Get function value at {@link #getHi()}.
+     * @return function value at {@link #getHi()}
+     */
+    double getFHi() {
+        return fHi;
+    }
+
+    /**
+     * @return a point in the middle of the bracket.
+     * @see #getFMid()
+     */
+    double getMid() {
+        return mid;
+    }
+
+    /**
+     * Get function value at {@link #getMid()}.
+     * @return function value at {@link #getMid()}
+     */
+    double getFMid() {
+        return fMid;
+    }
+
+    /**
+     * Get the value of the function.
+     *
+     * @param func Function.
+     * @param x Point.
+     * @return the value
+     * @throws IllegalStateException if the maximal number of evaluations is exceeded.
+     */
+    private double value(DoubleUnaryOperator func, double x) {
+        if (evaluations >= maxEvaluations) {
+            throw new IllegalStateException("Too many evaluations: " + evaluations);
+        }
+        evaluations++;
+        return func.applyAsDouble(x);
+    }
+}

--- a/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/BrentOptimizer.java
+++ b/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/BrentOptimizer.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import java.util.function.DoubleUnaryOperator;
+import org.apache.commons.numbers.core.Precision;
+
+/**
+ * For a function defined on some interval {@code (lo, hi)}, this class
+ * finds an approximation {@code x} to the point at which the function
+ * attains its minimum.
+ * It implements Richard Brent's algorithm (from his book "Algorithms for
+ * Minimization without Derivatives", p. 79) for finding minima of real
+ * univariate functions.
+ *
+ * <P>This code is an adaptation, partly based on the Python code from SciPy
+ * (module "optimize.py" v0.5); the original algorithm is also modified:
+ * <ul>
+ *  <li>to use an initial guess provided by the user,</li>
+ *  <li>to ensure that the best point encountered is the one returned.</li>
+ * </ul>
+ *
+ * <p>This class has been extracted from {@code o.a.c.math4.optim.univariate}
+ * and simplified to remove support for the UnivariateOptimizer interface.
+ * This removed the options: to find the maximum; use a custom convergence checker
+ * on the function value; and remove the maximum function evaluation count.
+ * The class now implements a single optimize method within the provided bracket
+ * from the given start position (with value).
+ *
+ * @since 1.1
+ */
+class BrentOptimizer {
+    /** Golden section. (3 - sqrt(5)) / 2. */
+    private static final double GOLDEN_SECTION = 0.3819660112501051;
+    /** Minimum relative tolerance. 2 * eps = 2^-51. */
+    private static final double MIN_RELATIVE_TOLERANCE = 0x1.0p-51;
+
+    /** Relative threshold. */
+    private final double relativeThreshold;
+    /** Absolute threshold. */
+    private final double absoluteThreshold;
+    /** The number of function evaluations from the most recent call to optimize. */
+    private int evaluations;
+
+    /**
+     * This class holds a point and the value of an objective function at this
+     * point. This is a simple immutable container.
+     *
+     * @since 1.1
+     */
+    static final class PointValuePair {
+        /** Point. */
+        private final double point;
+        /** Value of the objective function at the point. */
+        private final double value;
+
+        /**
+         * @param point Point.
+         * @param value Value of an objective function at the point.
+         */
+        private PointValuePair(double point, double value) {
+            this.point = point;
+            this.value = value;
+        }
+
+        /**
+         * Create a point/objective function value pair.
+         *
+         * @param point Point.
+         * @param value Value of an objective function at the point.
+         * @return the pair
+         */
+        static PointValuePair of(double point, double value) {
+            return new PointValuePair(point, value);
+        }
+
+        /**
+         * Get the point.
+         *
+         * @return the point.
+         */
+        double getPoint() {
+            return point;
+        }
+
+        /**
+         * Get the value of the objective function.
+         *
+         * @return the stored value of the objective function.
+         */
+        double getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * The arguments are used to implement the original stopping criterion
+     * of Brent's algorithm.
+     * {@code abs} and {@code rel} define a tolerance
+     * {@code tol = rel |x| + abs}. {@code rel} should be no smaller than
+     * <em>2 macheps</em> and preferably not much less than <em>sqrt(macheps)</em>,
+     * where <em>macheps</em> is the relative machine precision. {@code abs} must
+     * be positive.
+     *
+     * @param rel Relative threshold.
+     * @param abs Absolute threshold.
+     * @throws IllegalArgumentException if {@code abs <= 0}; or if {@code rel < 2 * Math.ulp(1.0)}
+     */
+    BrentOptimizer(double rel, double abs) {
+        if (rel >= MIN_RELATIVE_TOLERANCE) {
+            relativeThreshold = rel;
+            absoluteThreshold = Arguments.checkStrictlyPositive(abs);
+        } else {
+            // relative too small, or NaN
+            throw new InferenceException(InferenceException.X_LT_Y, rel, MIN_RELATIVE_TOLERANCE);
+        }
+    }
+
+    /**
+     * Gets the number of function evaluations from the most recent call to
+     * {@link #optimize(DoubleUnaryOperator, double, double, double, double) optimize}.
+     *
+     * @return the function evaluations
+     */
+    int getEvaluations() {
+        return evaluations;
+    }
+
+    /**
+     * Search for the minimum inside the provided interval. The bracket must satisfy
+     * the equalities {@code lo < mid < hi} or {@code hi < mid < lo}.
+     *
+     * <p>Note: This function accepts the initial guess and the function value at that point.
+     * This is done for convenience as this internal class is used where the caller already
+     * knows the function value.
+     *
+     * @param func Function to solve.
+     * @param lo Lower bound of the search interval.
+     * @param hi Higher bound of the search interval.
+     * @param mid Start point.
+     * @param fMid Function value at the start point.
+     * @return the value where the function is minimum.
+     * @throws IllegalArgumentException if start point is not within the search interval
+     * @throws IllegalStateException if the maximum number of iterations is exceeded
+     */
+    PointValuePair optimize(DoubleUnaryOperator func,
+                            double lo, double hi,
+                            double mid, double fMid) {
+        double a;
+        double b;
+        if (lo < hi) {
+            a = lo;
+            b = hi;
+        } else {
+            a = hi;
+            b = lo;
+        }
+        if (!(a < mid && mid < b)) {
+            throw new InferenceException("Invalid bounds: (%s, %s) with start %s", a, b, mid);
+        }
+        double x = mid;
+        double v = x;
+        double w = x;
+        double d = 0;
+        double e = 0;
+        double fx = fMid;
+        double fv = fx;
+        double fw = fx;
+
+        // Best point encountered so far (which is the initial guess).
+        double bestX = x;
+        double bestFx = fx;
+
+        // No test for iteration count.
+        // Note that the termination criterion is based purely on the size of the current
+        // bracket and the current point x. If the function evaluates NaN then golden
+        // section steps are taken.
+        evaluations = 0;
+        for (;;) {
+            final double m = 0.5 * (a + b);
+            final double tol1 = relativeThreshold * Math.abs(x) + absoluteThreshold;
+            final double tol2 = 2 * tol1;
+
+            // Default termination (Brent's criterion).
+            if (Math.abs(x - m) <= tol2 - 0.5 * (b - a)) {
+                return PointValuePair.of(bestX, bestFx);
+            }
+
+            if (Math.abs(e) > tol1) {
+                // Fit parabola.
+                double r = (x - w) * (fx - fv);
+                double q = (x - v) * (fx - fw);
+                double p = (x - v) * q - (x - w) * r;
+                q = 2 * (q - r);
+
+                if (q > 0) {
+                    p = -p;
+                } else {
+                    q = -q;
+                }
+
+                r = e;
+                e = d;
+
+                if (p > q * (a - x) &&
+                    p < q * (b - x) &&
+                    Math.abs(p) < Math.abs(0.5 * q * r)) {
+                    // Parabolic interpolation step.
+                    d = p / q;
+                    final double u = x + d;
+
+                    // f must not be evaluated too close to a or b.
+                    if (u - a < tol2 || b - u < tol2) {
+                        if (x <= m) {
+                            d = tol1;
+                        } else {
+                            d = -tol1;
+                        }
+                    }
+                } else {
+                    // Golden section step.
+                    if (x < m) {
+                        e = b - x;
+                    } else {
+                        e = a - x;
+                    }
+                    d = GOLDEN_SECTION * e;
+                }
+            } else {
+                // Golden section step.
+                if (x < m) {
+                    e = b - x;
+                } else {
+                    e = a - x;
+                }
+                d = GOLDEN_SECTION * e;
+            }
+
+            // Update by at least "tol1".
+            // Here d is never NaN so the evaluation point u is always finite.
+            double u;
+            if (Math.abs(d) < tol1) {
+                if (d >= 0) {
+                    u = x + tol1;
+                } else {
+                    u = x - tol1;
+                }
+            } else {
+                u = x + d;
+            }
+
+            evaluations++;
+            final double fu = func.applyAsDouble(u);
+
+            // Maintain the best encountered result
+            if (fu < bestFx) {
+                bestX = u;
+                bestFx = fu;
+            }
+
+            // Note:
+            // Here the use of a convergence checker on f(x) previous vs current has been removed.
+            // Typically when the checker requires a very small relative difference
+            // the optimizer will stop before, or soon after, on Brent's criterion when that is
+            // configured with the smallest recommended convergence criteria.
+
+            // Update a, b, v, w and x.
+            if (fu <= fx) {
+                if (u < x) {
+                    b = x;
+                } else {
+                    a = x;
+                }
+                v = w;
+                fv = fw;
+                w = x;
+                fw = fx;
+                x = u;
+                fx = fu;
+            } else {
+                if (u < x) {
+                    a = u;
+                } else {
+                    b = u;
+                }
+                if (fu <= fw ||
+                    Precision.equals(w, x)) {
+                    v = w;
+                    fv = fw;
+                    w = u;
+                    fw = fu;
+                } else if (fu <= fv ||
+                           Precision.equals(v, x) ||
+                           Precision.equals(v, w)) {
+                    v = u;
+                    fv = fu;
+                }
+            }
+        }
+    }
+}

--- a/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/Hypergeom.java
+++ b/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/Hypergeom.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import org.apache.commons.statistics.distribution.HypergeometricDistribution;
+
+/**
+ * Provide a wrapper around the {@link HypergeometricDistribution} that caches
+ * all probability mass values.
+ *
+ * <p>This class extracts the logic from the HypergeometricDistribution implementation
+ * used for the cumulative probability functions. It allows fast computation of
+ * the CDF and SF for the entire supported domain.
+ *
+ * @since 1.1
+ */
+class Hypergeom {
+    /** 1/2. */
+    private static final double HALF = 0.5;
+    /** The lower bound of the support (inclusive). */
+    private final int lowerBound;
+    /** The upper bound of the support (inclusive). */
+    private final int upperBound;
+    /** Cached probability values. This holds values from x=0 even though the supported
+     * lower bound may be above x=0. This allows x to be used as an index without offsetting
+     * using the lower bound. */
+    private final double[] prob;
+    /** Cached midpoint, m, of the CDF/SF. This is not the true median. It is the value where
+     * the CDF is closest to 0.5; as such the CDF(m) may be below 0.5 if the next value
+     * CDF(m+1) is further from 0.5. Used for the cumulative probability functions. */
+    private final int m;
+    /** Cached CDF of the midpoint.
+     * Used for the cumulative probability functions. */
+    private final double midCDF;
+    /** Lower mode. */
+    private final int m1;
+    /** Upper mode. */
+    private final int m2;
+
+    /**
+     * @param populationSize Population size.
+     * @param numberOfSuccesses Number of successes in the population.
+     * @param sampleSize Sample size.
+     */
+    Hypergeom(int populationSize,
+              int numberOfSuccesses,
+              int sampleSize) {
+        final HypergeometricDistribution dist =
+            HypergeometricDistribution.of(populationSize, numberOfSuccesses, sampleSize);
+
+        // Cache all values required to compute the cumulative probability functions
+
+        // Bounds
+        lowerBound = dist.getSupportLowerBound();
+        upperBound = dist.getSupportUpperBound();
+
+        // PMF values
+        prob = new double[upperBound + 1];
+        for (int x = lowerBound; x <= upperBound; x++) {
+            prob[x] = dist.probability(x);
+        }
+
+        // Compute mid-point for CDF/SF computation
+        // Find the closest sum(PDF) to 0.5.
+        int x = lowerBound;
+        double p0 = 0;
+        double p1 = prob[x];
+        // No check of the upper bound required here as the CDF should sum to 1 and 0.5
+        // is exceeded before a bounds error.
+        while (p1 < HALF) {
+            x++;
+            p0 = p1;
+            p1 += prob[x];
+        }
+        // p1 >= 0.5 > p0
+        // Pick closet
+        if (p1 - HALF >= HALF - p0) {
+            x--;
+            p1 = p0;
+        }
+        m = x;
+        midCDF = p1;
+
+        // Compute the mode (lower != upper in the case where v is integer).
+        // This value is used by the UnconditionedExactTest and is cached here for convenience.
+        final double v = ((double) numberOfSuccesses + 1) * ((double) sampleSize + 1) / (populationSize + 2.0);
+        m1 = (int) Math.ceil(v) - 1;
+        m2 = (int) Math.floor(v);
+    }
+
+    /**
+     * Get the lower bound of the support.
+     *
+     * @return lower bound
+     */
+    int getSupportLowerBound() {
+        return lowerBound;
+    }
+
+    /**
+     * Get the upper bound of the support.
+     *
+     * @return upper bound
+     */
+    int getSupportUpperBound() {
+        return upperBound;
+    }
+
+    /**
+     * Get the lower mode of the distribution.
+     *
+     * @return lower mode
+     */
+    int getLowerMode() {
+        return m1;
+    }
+
+    /**
+     * Get the upper mode of the distribution.
+     *
+     * @return upper mode
+     */
+    int getUpperMode() {
+        return m2;
+    }
+
+    /**
+     * Compute the probability mass function (PMF) at the specified value.
+     *
+     * @param x Value.
+     * @return P(X = x)
+     * @throws IndexOutOfBoundsException if the value {@code x} is not in the supported domain.
+     */
+    double pmf(int x) {
+        return prob[x];
+    }
+
+    /**
+     * Compute the cumulative distribution function (CDF) at the specified value.
+     *
+     * @param x Value.
+     * @return P(X <= x)
+     */
+    double cdf(int x) {
+        if (x < lowerBound) {
+            return 0.0;
+        } else if (x >= upperBound) {
+            return 1.0;
+        }
+        if (x < m) {
+            return innerCumulativeProbability(lowerBound, x);
+        } else if (x > m) {
+            return 1 - innerCumulativeProbability(upperBound, x + 1);
+        }
+        // cdf(x)
+        return midCDF;
+    }
+
+    /**
+     * Compute the survival function (SF) at the specified value. This is the complementary
+     * cumulative distribution function.
+     *
+     * @param x Value.
+     * @return P(X > x)
+     */
+    double sf(int x) {
+        if (x < lowerBound) {
+            return 1.0;
+        } else if (x >= upperBound) {
+            return 0.0;
+        }
+        if (x < m) {
+            return 1 - innerCumulativeProbability(lowerBound, x);
+        } else if (x > m) {
+            return innerCumulativeProbability(upperBound, x + 1);
+        }
+        // 1 - cdf(x)
+        return 1 - midCDF;
+    }
+
+    /**
+     * For this distribution, {@code X}, this method returns
+     * {@code P(x0 <= X <= x1)}.
+     * This probability is computed by summing the point probabilities for the
+     * values {@code x0, x0 + dx, x0 + 2 * dx, ..., x1}; the direction {@code dx} is determined
+     * using a comparison of the input bounds.
+     * This should be called by using {@code x0} as the domain limit and {@code x1}
+     * as the internal value. This will result in a sum of increasingly larger magnitudes.
+     *
+     * @param x0 Inclusive domain bound.
+     * @param x1 Inclusive internal bound.
+     * @return {@code P(x0 <= X <= x1)}.
+     */
+    private double innerCumulativeProbability(int x0, int x1) {
+        // Assume the range is within the domain.
+        int x = x0;
+        double ret = prob[x];
+        if (x0 < x1) {
+            while (x != x1) {
+                x++;
+                ret += prob[x];
+            }
+        } else {
+            while (x != x1) {
+                x--;
+                ret += prob[x];
+            }
+        }
+        return ret;
+    }
+}

--- a/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/InferenceException.java
+++ b/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/InferenceException.java
@@ -50,10 +50,12 @@ class InferenceException extends IllegalArgumentException {
     static final String NOT_STRICTLY_POSITIVE = "Number %s is not greater than 0";
     /** Error message for "no data" condition. */
     static final String NO_DATA = "No data";
-    /** Error message for "too large" condition when "x > y". */
+    /** Error message for "too large" condition when "{@code x > y}". */
     static final String X_GT_Y = "%s > %s";
-    /** Error message for "too large" condition when "x >= y". */
+    /** Error message for "too large" condition when "{@code x >= y}". */
     static final String X_GTE_Y = "%s >= %s";
+    /** Error message for "too small" condition when "{@code x < y}". */
+    static final String X_LT_Y = "%s < %s";
 
     /** Serializable version identifier. */
     private static final long serialVersionUID = 20221203L;

--- a/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/UnconditionedExactTest.java
+++ b/commons-statistics-inference/src/main/java/org/apache/commons/statistics/inference/UnconditionedExactTest.java
@@ -1,0 +1,1145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.DoublePredicate;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.IntToDoubleFunction;
+
+import org.apache.commons.numbers.combinatorics.LogBinomialCoefficient;
+import org.apache.commons.statistics.inference.BrentOptimizer.PointValuePair;
+
+/**
+ * Implements an unconditioned exact test for a contingency table.
+ *
+ * <p>Performs an exact test for the statistical significance of the association (contingency)
+ * between two kinds of categorical classification. A 2x2 contingency table is:
+ *
+ * <p>\[ \left[ {\begin{array}{cc}
+ *         a &amp; b \\
+ *         c &amp; d \\
+ *       \end{array} } \right] \]
+ *
+ * <p>This test applies to the case of a 2x2 contingency table with one margin fixed. Note that
+ * if both margins are fixed (the row sums and column sums are not random)
+ * then Fisher's exact test can be applied.
+ *
+ * <p>This implementation fixes the column sums \( m = a + c \) and \( n = b + d \).
+ * All possible tables can be created using \( 0 \le a \le m \) and \( 0 \le b \le n \).
+ * The random values \( a \) and \( b \) follow a binomial distribution with probabilities
+ * \( p_0 \) and \( p_1 \) such that \( a \sim B(m, p_0) \) and \( b \sim B(n, p_1) \).
+ * The p-value of the 2x2 table is the product of two binomials:
+ *
+ * <p>\[ \begin{aligned}
+ *       p &amp;= Pr(a; m, p_0) \times Pr(b; n, p_1) \\
+ *         &amp;= \binom{m}{a} p_0^a (1-p_0)^{m-a} \times \binom{n}{b} p_1^b (1-p_1)^{n-b} \end{aligned} \]
+ *
+ * <p>For the binomial model, the null hypothesis is the two nuisance parameters are equal
+ * \( p_0 = p_1 = \pi\), with \( \pi \) the probability for equal proportions, and the probability
+ * of any single table is:
+ *
+ * <p>\[ p = \binom{m}{a} \binom{n}{b} \pi^{a+b} (1-\pi)^{m+n-a-b} \]
+ *
+ * <p>The p-value of the observed table is calculated by maximising the sum of the as or more
+ * extreme tables over the domain of the nuisance parameter \( 0 \lt \pi \lt 1 \):
+ *
+ * <p>\[ p(a, b) = \sum_{i,j} \binom{m}{i} \binom{n}{j} \pi^{i+j} (1-\pi)^{m+n-i-j} \]
+ *
+ * <p>where table \( (i,j) \) is as or more extreme than the observed table \( (a, b) \). The test
+ * can be configured to select more extreme tables using various {@linkplain Method methods}.
+ *
+ * <p>Note that the sum of the joint binomial distribution is a univariate function for
+ * the nuisance parameter \( \pi \). This function may have many local maxima and the
+ * search enumerates the range with a configured {@linkplain #withInitialPoints(int)
+ * number of points}. The best candidates are optionally used as the start point for an
+ * {@linkplain #withOptimize(boolean) optimized} search for a local maxima.
+ *
+ * <p>References:
+ * <ol>
+ * <li>
+ * Barnard, G.A. (1947).
+ * <a href="https://doi.org/10.1093/biomet/34.1-2.123">Significance tests for 2x2 tables.</a>
+ * Biometrika, 34, Issue 1-2, 123–138.
+ * <li>
+ * Boschloo, R.D. (1970).
+ * <a href="https://doi.org/10.1111/j.1467-9574.1970.tb00104.x">Raised conditional level of
+ * significance for the 2 × 2-table when testing the equality of two probabilities.</a>
+ * Statistica neerlandica, 24(1), 1–9.
+ * <li>
+ * Suisaa, A and Shuster, J.J. (1985).
+ * <a href="https://doi.org/10.2307/2981892">Exact Unconditional Sample Sizes
+ * for the 2 × 2 Binomial Trial.</a>
+ * Journal of the Royal Statistical Society. Series A (General), 148(4), 317-327.
+ * </ol>
+ *
+ * @see FisherExactTest
+ * @see <a href="https://en.wikipedia.org/wiki/Boschloo%27s_test">Boschloo&#39;s test (Wikipedia)</a>
+ * @see <a href="https://en.wikipedia.org/wiki/Barnard%27s_test">Barnard&#39;s test (Wikipedia)</a>
+ * @since 1.1
+ */
+public final class UnconditionedExactTest {
+    /**
+     * Default instance.
+     *
+     * <p>SciPy's boschloo_exact and barnard_exact tests use 32 points in the interval [0,
+     * 1) The R Exact package uses 100 in the interval [1e-5, 1-1e-5]. Barnards 1947 paper
+     * describes the nuisance parameter in the open interval {@code 0 < pi < 1}. Here we
+     * respect the open-interval for the initial candidates and ignore 0 and 1. The
+     * initial bounds used are the same as the R Exact package. We closely match the inner
+     * 31 points from SciPy by using 33 points by default.
+     */
+    private static final UnconditionedExactTest DEFAULT = new UnconditionedExactTest(
+        AlternativeHypothesis.TWO_SIDED, Method.BOSCHLOO, 33, true);
+    /** Lower bound for the enumerated interval. The upper bound is {@code 1 - lower}. */
+    private static final double LOWER_BOUND = 1e-5;
+    /** Relative epsilon for the Brent solver. This is limited for a univariate function
+     * to approximately sqrt(eps) with eps = 2^-52. */
+    private static final double SOLVER_RELATIVE_EPS = 1.4901161193847656E-8;
+    /** Fraction of the increment (interval between enumerated points) to initialise the bracket
+     * for the minima. Note the minima should lie between x +/- increment. The bracket should
+     * search within this range. Set to 1/8 and so the initial point of the bracket is
+     * approximately 1.61 * 1/8 = 0.2 of the increment away from initial points a or b. */
+    private static final double INC_FRACTION = 0.125;
+    /** Maximum number of candidate to optimize. This is a safety limit to avoid excess
+     * optimization. Only candidates within a relative tolerance of the best candidate are
+     * stored. If the number of candidates exceeds this value then many candidates have a
+     * very similar p-value and the top candidates will be optimized. Using a value of 3
+     * allows at least one other candidate to be optimized when there is two-fold
+     * symmetry in the energy function. */
+    private static final int MAX_CANDIDATES = 3;
+    /** Relative distance of candidate minima from the lowest candidate. Used to exclude
+     * poor candidates from optimization. */
+    private static final double MINIMA_EPS = 0.02;
+    /** The maximum number of tables. This is limited by the maximum number of indices that
+     * can be maintained in memory. Potentially up to this number of tables must be tracked
+     * during computation of the p-value for as or more extreme tables. The limit is set
+     * using the same limit for maximum capacity as java.util.ArrayList. In practice any
+     * table anywhere near this limit can be computed using an alternative such as a chi-squared
+     * or g test. */
+    private static final int MAX_TABLES = Integer.MAX_VALUE - 8;
+    /** Error message text for zero column sums. */
+    private static final String COLUMN_SUM = "Column sum";
+
+    /** Alternative hypothesis. */
+    private final AlternativeHypothesis alternative;
+    /** Method to identify more extreme tables. */
+    private final Method method;
+    /** Number of initial points. */
+    private final int points;
+    /** Option to optimize the best initial point(s). */
+    private final boolean optimize;
+
+    /**
+     * Define the method to determine the more extreme tables.
+     *
+     * @since 1.1
+     */
+    public enum Method {
+        /**
+         * Uses the test statistic from a Z-test using a pooled variance.
+         *
+         * <p>\[ T(X) = \frac{\hat{p}_0 - \hat{p}_1}{\sqrt{\hat{p}(1 - \hat{p}) (\frac{1}{m} + \frac{1}{n})}} \]
+         *
+         * <p>where \( \hat{p}_0 = a / m \), \( \hat{p}_1 = b / n \), and
+         * \( \hat{p} = (a+b) / (m+n) \) are the estimators of \( p_0 \), \( p_1 \) and the
+         * pooled probability \( p \) assuming \( p_0 = p_1 \).
+         *
+         * <p>The more extreme tables are identified using the {@link AlternativeHypothesis}:
+         * <ul>
+         * <li>greater: \( T(X) \ge T(X_0) \)
+         * <li>less: \( T(X) \le T(X_0) \)
+         * <li>two-sided: \( | T(X) | \ge | T(X_0) | \)
+         * </ul>
+         *
+         * <p>The use of the Z statistic was suggested by Suissa and Shuster (1985).
+         * This method is uniformly more powerful than Fisher's test for balanced designs
+         * (\( m = n \)).
+         */
+        Z_POOLED,
+
+        /**
+         * Uses the test statistic from a Z-test using an unpooled variance.
+         *
+         * <p>\[ T(X) = \frac{\hat{p}_0 - \hat{p}_1}
+         * {\sqrt{ \frac{\hat{p}_0(1 - \hat{p}_0)}{m} + \frac{\hat{p}_1(1 - \hat{p}_1)}{n}} } \]
+         *
+         * <p>where \( \hat{p}_0 = a / m \) and \( \hat{p}_1 = b / n \).
+         *
+         * <p>The more extreme tables are identified using the {@link AlternativeHypothesis} as
+         * per the {@link #Z_POOLED} method.
+         */
+        Z_UNPOOLED,
+
+        /**
+         * Uses the p-value from Fisher's exact test. This is also known as Boschloo's test.
+         *
+         * <p>The p-value for Fisher's test is computed using using the
+         * {@link AlternativeHypothesis}. The more extreme tables are identified using
+         * \( p(X) \le p(X_0) \).
+         *
+         * <p>This method is always uniformly more powerful than Fisher's test.
+         *
+         * @see FisherExactTest
+         */
+        BOSCHLOO;
+    }
+
+    /**
+     * Result for the unconditioned exact test.
+     *
+     * <p>This class is immutable.
+     *
+     * @since 1.1
+     */
+    public static final class Result extends BaseSignificanceResult {
+        /** Nuisance parameter. */
+        private final double pi;
+
+        /**
+         * Create an instance where all tables are more extreme, i.e. the p-value
+         * is 1.0.
+         *
+         * @param statistic Test statistic.
+         */
+        Result(double statistic) {
+            super(statistic, 1);
+            this.pi = 0.5;
+        }
+
+        /**
+         * @param statistic Test statistic.
+         * @param pi Nuisance parameter.
+         * @param p Result p-value.
+         */
+        Result(double statistic, double pi, double p) {
+            super(statistic, p);
+            this.pi = pi;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>The value of the statistic is dependent on the {@linkplain Method method}
+         * used to determine the more extreme tables.
+         */
+        @Override
+        public double getStatistic() {
+            // Note: This method is here for documentation
+            return super.getStatistic();
+        }
+
+        /**
+         * Gets the nuisance parameter that maximised the probability sum of the as or more
+         * extreme tables.
+         *
+         * @return the nuisance parameter.
+         */
+        public double getNuisanceParameter() {
+            return pi;
+        }
+    }
+
+    /**
+     * An expandable list of (x,y) values. This allows tracking 2D positions stored as
+     * a single index.
+     */
+    private static class XYList {
+        /** The maximum size of array to allocate. */
+        private final int max;
+        /** Width, or maximum x value (exclusive). */
+        private final int width;
+
+        /** The size of the list. */
+        private int size;
+        /** The list data. */
+        private int[] data = new int[10];
+
+        /**
+         * Create an instance. It is assumed that (maxx+1)*(maxy+1) does not exceed the
+         * capacity of an array.
+         *
+         * @param maxx Maximum x-value (inclusive).
+         * @param maxy Maximum y-value (inclusive).
+         */
+        XYList(int maxx, int maxy) {
+            this.width = maxx + 1;
+            this.max = width * (maxy + 1);
+        }
+
+        /**
+         * Gets the width.
+         * (x, y) values are stored using y * width + x.
+         *
+         * @return the width
+         */
+        int getWidth() {
+            return width;
+        }
+
+        /**
+         * Gets the maximum X value (inclusive).
+         *
+         * @return the max X
+         */
+        int getMaxX() {
+            return width - 1;
+        }
+
+        /**
+         * Gets the maximum Y value (inclusive).
+         *
+         * @return the max Y
+         */
+        int getMaxY() {
+            return max / width - 1;
+        }
+
+        /**
+         * Adds the value to the list.
+         *
+         * @param x X value.
+         * @param y Y value.
+         */
+        void add(int x, int y) {
+            if (size == data.length) {
+                // Overflow safe doubling of the current size.
+                data = Arrays.copyOf(data, (int) Math.min(max, size * 2L));
+            }
+            data[size++] = width * y + x;
+        }
+
+        /**
+         * Gets the 2D index at the specified {@code index}.
+         * The index is y * width + x:
+         * <pre>
+         * x = index % width
+         * y = index / width
+         * </pre>
+         *
+         * @param index Element index.
+         * @return the 2D index
+         */
+        int get(int index) {
+            return data[index];
+        }
+
+        /**
+         * Gets the number of elements in the list.
+         *
+         * @return the size
+         */
+        int size() {
+            return size;
+        }
+
+        /**
+         * Checks if the list size is zero.
+         *
+         * @return true if empty
+         */
+        boolean isEmpty() {
+            return size == 0;
+        }
+
+        /**
+         * Checks if the list is the maximum capacity.
+         *
+         * @return true if full
+         */
+        boolean isFull() {
+            return size == max;
+        }
+    }
+
+    /**
+     * A container of (key,value) pairs to store candidate minima. Encapsulates the
+     * logic of storing multiple initial search points for optimization.
+     *
+     * <p>Stores all pairs within a relative tolerance of the lowest minima up to a set
+     * capacity. When at capacity the worst candidate is replaced by addition of a
+     * better candidate.
+     *
+     * <p>Special handling is provided to store only a single NaN value if no non-NaN
+     * values have been observed. This prevents storing a large number of NaN
+     * candidates.
+     */
+    static class Candidates {
+        /** The maximum size of array to allocate. */
+        private final int max;
+        /** Relative distance from lowest candidate. */
+        private final double eps;
+        /** Candidate (key,value) pairs. */
+        private double[][] data;
+        /** Current size of the list. */
+        private int size;
+        /** Current minimum. */
+        private double min = Double.POSITIVE_INFINITY;
+        /** Current threshold for inclusion. */
+        private double threshold = Double.POSITIVE_INFINITY;
+
+        /**
+         * Create an instance.
+         *
+         * @param max Maximum number of allowed candidates (limited to at least 1).
+         * @param eps Relative distance of candidate minima from the lowest candidate
+         * (assumed to be positive and finite).
+         */
+        Candidates(int max, double eps) {
+            this.max = Math.max(1, max);
+            this.eps = eps;
+            // Create the initial storage
+            data = new double[Math.min(this.max, 4)][];
+        }
+
+        /**
+         * Adds the (key, value) pair.
+         *
+         * @param k Key.
+         * @param v Value.
+         */
+        void add(double k, double v) {
+            // Store only a single NaN
+            if (Double.isNaN(v)) {
+                if (size == 0) {
+                    // No requirement to check capacity
+                    data[size++] = new double[] {k, v};
+                }
+                return;
+            }
+            // Here values are non-NaN.
+            // If higher then do not store.
+            if (v > threshold) {
+                return;
+            }
+            // Check if lower than the current minima.
+            if (v < min) {
+                min = v;
+                // Get new threshold
+                threshold = v + Math.abs(v) * eps;
+                // Remove existing entries above the threshold
+                int s = 0;
+                for (int i = 0; i < size; i++) {
+                    // This will filter NaN values
+                    if (data[i][1] <= threshold) {
+                        data[s++] = data[i];
+                    }
+                }
+                size = s;
+                // Caution: This does not clear stale data
+                // by setting all values in [newSize, oldSize) = null
+            }
+            addPair(k, v);
+        }
+
+        /**
+         * Add the (key, value) pair to the data.
+         * It is assumed the data satisfy the conditions for addition.
+         *
+         * @param k Key.
+         * @param v Value.
+         */
+        private void addPair(double k, double v) {
+            if (size == data.length) {
+                if (size == max) {
+                    // At capacity.
+                    replaceWorst(k, v);
+                    return;
+                }
+                // Expand
+                data = Arrays.copyOfRange(data, 0, (int) Math.min(max, size * 2L));
+            }
+            data[size++] = new double[] {k, v};
+        }
+
+        /**
+         * Replace the worst candidate.
+         *
+         * @param k Key.
+         * @param v Value.
+         */
+        private void replaceWorst(double k, double v) {
+            // Note: This only occurs when NaN values have been removed by addition
+            // of non-NaN values.
+            double[] worst = data[0];
+            for (int i = 1; i < size; i++) {
+                if (worst[1] < data[i][1]) {
+                    worst = data[i];
+                }
+            }
+            worst[0] = k;
+            worst[1] = v;
+        }
+
+        /**
+         * Return the minimum (key,value) pair.
+         *
+         * @return the minimum (or null)
+         */
+        double[] getMinimum() {
+            // This will handle size=0 as data[0] will be null
+            double[] best = data[0];
+            for (int i = 1; i < size; i++) {
+                if (best[1] > data[i][1]) {
+                    best = data[i];
+                }
+            }
+            return best;
+        }
+
+        /**
+         * Perform the given action for each (key, value) pair.
+         *
+         * @param action Action.
+         */
+        void forEach(Consumer<double[]> action) {
+            for (int i = 0; i < size; i++) {
+                action.accept(data[i]);
+            }
+        }
+    }
+
+    /**
+     * Compute the statistic for Boschloo's test.
+     */
+    private interface BoschlooStatistic {
+        /**
+         * Compute Fisher's p-value for the 2x2 contingency table with the observed
+         * value {@code x} in position [0][0]. Note that the table margins are fixed
+         * and are defined by the population size, number of successes and sample
+         * size of the specified hypergeometric distribution.
+         *
+         * @param dist Hypergeometric distribution.
+         * @param x Value.
+         * @return Fisher's p-value
+         */
+        double value(Hypergeom dist, int x);
+    }
+
+    /**
+     * @param alternative Alternative hypothesis.
+     * @param method Method to identify more extreme tables.
+     * @param points Number of initial points.
+     * @param optimize Option to optimize the best initial point(s).
+     */
+    private UnconditionedExactTest(AlternativeHypothesis alternative,
+                                   Method method,
+                                   int points,
+                                   boolean optimize) {
+        this.alternative = alternative;
+        this.method = method;
+        this.points = points;
+        this.optimize = optimize;
+    }
+
+    /**
+     * Return an instance using the default options.
+     *
+     * <ul>
+     * <li>{@link AlternativeHypothesis#TWO_SIDED}
+     * <li>{@link Method#BOSCHLOO}
+     * <li>{@linkplain #withInitialPoints(int) points = 33}
+     * <li>{@linkplain #withOptimize(boolean) optimize = true}
+     * </ul>
+     *
+     * @return default instance
+     */
+    public static UnconditionedExactTest withDefaults() {
+        return DEFAULT;
+    }
+
+    /**
+     * Return an instance with the configured alternative hypothesis.
+     *
+     * @param v Value.
+     * @return an instance
+     */
+    public UnconditionedExactTest with(AlternativeHypothesis v) {
+        return new UnconditionedExactTest(Objects.requireNonNull(v), method, points, optimize);
+    }
+
+    /**
+     * Return an instance with the configured method.
+     *
+     * @param v Value.
+     * @return an instance
+     */
+    public UnconditionedExactTest with(Method v) {
+        return new UnconditionedExactTest(alternative, Objects.requireNonNull(v), points, optimize);
+    }
+
+    /**
+     * Return an instance with the configured number of initial points.
+     *
+     * <p>The search for the nuisance parameter will use \( v \) points in the open interval
+     * \( (0, 1) \). The interval is evaluated by including start and end points approximately
+     * equal to 0 and 1. Additional internal points are enumerated using increments of
+     * approximately \( \frac{1}{v-1} \). The minimum number of points is 2. Increasing the
+     * number of points increases the precision of the search at the cost of performance.
+     *
+     * <p>To approximately double the number of points so that all existing points are included
+     * and additional points half-way between them are sampled requires using {@code 2p - 1}
+     * where {@code p} is the existing number of points.
+     *
+     * @param v Value.
+     * @return an instance
+     * @throws IllegalArgumentException if the value is {@code < 2}.
+     */
+    public UnconditionedExactTest withInitialPoints(int v) {
+        if (v <= 1) {
+            throw new InferenceException(InferenceException.X_LT_Y, v, 2);
+        }
+        return new UnconditionedExactTest(alternative, method, v, optimize);
+    }
+
+    /**
+     * Return an instance with the configured optimization of initial search points.
+     *
+     * <p>If enabled then the initial point(s) with the highest probability is/are used as the start
+     * for an optimization to find a local maxima.
+     *
+     * @param v Value.
+     * @return an instance
+     * @see #withInitialPoints(int)
+     */
+    public UnconditionedExactTest withOptimize(boolean v) {
+        return new UnconditionedExactTest(alternative, method, points, v);
+    }
+
+    /**
+     * Compute the statistic for the unconditioned exact test. The statistic returned
+     * depends on the configured {@linkplain Method method}.
+     *
+     * @param table 2-by-2 contingency table.
+     * @return test statistic
+     * @throws IllegalArgumentException if the {@code table} is not a 2-by-2 table; any
+     * table entry is negative; any column sum is zero; the table sum is zero or not an
+     * integer; or the number of possible tables exceeds the maximum array capacity.
+     * @see #with(Method)
+     * @see #test(int[][])
+     */
+    public double statistic(int[][] table) {
+        checkTable(table);
+        final int a = table[0][0];
+        final int b = table[0][1];
+        final int c = table[1][0];
+        final int d = table[1][1];
+        final int m = a + c;
+        final int n = b + d;
+        switch (method) {
+        case Z_POOLED:
+            return statisticZ(a, b, m, n, true);
+        case Z_UNPOOLED:
+            return statisticZ(a, b, m, n, false);
+        case BOSCHLOO:
+            return statisticBoschloo(a, b, m, n);
+        default:
+            throw new IllegalStateException(String.valueOf(method));
+        }
+    }
+
+    /**
+     * Performs an unconditioned exact test on the 2-by-2 contingency table. The statistic and
+     * p-value returned depends on the configured {@linkplain Method method} and
+     * {@linkplain AlternativeHypothesis alternative hypothesis}.
+     *
+     * <p>The search for the nuisance parameter that maximises the p-value can be configured to:
+     * start with a number of {@linkplain #withInitialPoints(int) initial points}; and
+     * {@linkplain #withOptimize(boolean) optimize} the best points.
+     *
+     * @param table 2-by-2 contingency table.
+     * @return test result
+     * @throws IllegalArgumentException if the {@code table} is not a 2-by-2 table; any
+     * table entry is negative; any column sum is zero; the table sum is zero or not an
+     * integer; or the number of possible tables exceeds the maximum array capacity.
+     * @see #with(Method)
+     * @see #with(AlternativeHypothesis)
+     * @see #statistic(int[][])
+     */
+    public Result test(int[][] table) {
+        checkTable(table);
+        final int a = table[0][0];
+        final int b = table[0][1];
+        final int c = table[1][0];
+        final int d = table[1][1];
+        final int m = a + c;
+        final int n = b + d;
+
+        // Used to track more extreme tables
+        final XYList list = new XYList(m, n);
+
+        final double statistic = findTables(a, b, list);
+        if (list.isEmpty() || list.isFull()) {
+            // All possible tables are more extreme, e.g. a two-sided test where the
+            // z-statistic is zero.
+            return new Result(statistic);
+        }
+        final double[] opt = computePValue(list);
+
+        return new Result(statistic, opt[0], opt[1]);
+    }
+
+    /**
+     * Find all tables that are as or more extreme than the observed table.
+     *
+     * <p>If the list of tables is full then all tables are more extreme.
+     * Some configurations can detect this without performing a search
+     * and in this case the list of tables is returned as empty.
+     *
+     * @param a Observed value for a.
+     * @param b Observed value for b.
+     * @param list List to track more extreme tables.
+     * @return the test statistic
+     */
+    private double findTables(int a, int b, XYList list) {
+        final int m = list.getMaxX();
+        final int n = list.getMaxY();
+        switch (method) {
+        case Z_POOLED:
+            return findTablesZ(a, b, m, n, true, list);
+        case Z_UNPOOLED:
+            return findTablesZ(a, b, m, n, false, list);
+        case BOSCHLOO:
+            return findTablesBoschloo(a, b, m, n, list);
+        default:
+            throw new IllegalStateException(String.valueOf(method));
+        }
+    }
+
+    /**
+     * Compute the statistic from a Z-test.
+     *
+     * @param a Observed value for a.
+     * @param b Observed value for b.
+     * @param m Column sum m.
+     * @param n Column sum n.
+     * @param pooled true to use a pooled variance.
+     * @return z
+     */
+    private static double statisticZ(int a, int b, int m, int n, boolean pooled) {
+        final double p0 = (double) a / m;
+        final double p1 = (double) b / n;
+        // Avoid NaN generation 0 / 0 when the variance is 0
+        if (p0 != p1) {
+            double variance;
+            if (pooled) {
+                // Integer sums will not overflow
+                final double p = (double) (a + b) / (m + n);
+                variance = p * (1 - p) * (1.0 / m + 1.0 / n);
+            } else {
+                variance = p0 * (1 - p0) / m + p1 * (1 - p1) / n;
+            }
+            return (p0 - p1) / Math.sqrt(variance);
+        }
+        return 0;
+    }
+
+    /**
+     * Find all tables that are as or more extreme than the observed table using the Z statistic.
+     *
+     * @param a Observed value for a.
+     * @param b Observed value for b.
+     * @param m Column sum m.
+     * @param n Column sum n.
+     * @param pooled true to use a pooled variance.
+     * @param list List to track more extreme tables.
+     * @return observed z
+     */
+    private double findTablesZ(int a, int b, int m, int n, boolean pooled, XYList list) {
+        final double statistic = statisticZ(a, b, m, n, pooled);
+        // Identify more extreme tables using the alternate hypothesis
+        DoublePredicate test;
+        if (alternative == AlternativeHypothesis.GREATER_THAN) {
+            test = z -> z >= statistic;
+        } else if (alternative == AlternativeHypothesis.LESS_THAN) {
+            test = z -> z <= statistic;
+        } else {
+            // two-sided
+            if (statistic == 0) {
+                // Early exit: all tables are as extreme
+                return 0;
+            }
+            final double za = Math.abs(statistic);
+            test = z -> Math.abs(z) >= za;
+        }
+        // Precompute factors
+        final double mn = (double) m + n;
+        final double norm = 1.0 / m + 1.0 / n;
+        double z;
+        // Process all possible tables
+        for (int i = 0; i <= m; i++) {
+            final double p0 = (double) i / m;
+            final double vp0 = p0 * (1 - p0) / m;
+            for (int j = 0; j <= n; j++) {
+                final double p1 = (double) j / n;
+                // Avoid NaN generation 0 / 0 when the variance is 0
+                if (p0 == p1) {
+                    z = 0;
+                } else {
+                    double variance;
+                    if (pooled) {
+                        // Integer sums will not overflow
+                        final double p = (i + j) / mn;
+                        variance = p * (1 - p) * norm;
+                    } else {
+                        variance = vp0 + p1 * (1 - p1) / n;
+                    }
+                    z = (p0 - p1) / Math.sqrt(variance);
+                }
+                if (test.test(z)) {
+                    list.add(i, j);
+                }
+            }
+        }
+        return statistic;
+    }
+
+    /**
+     * Compute the statistic using Fisher's p-value (also known as Boschloo's test).
+     *
+     * @param a Observed value for a.
+     * @param b Observed value for b.
+     * @param m Column sum m.
+     * @param n Column sum n.
+     * @return p-value
+     */
+    private double statisticBoschloo(int a, int b, int m, int n) {
+        final int nn = m + n;
+        final int k = a + b;
+        // Re-use the cached Hypergeometric implementation to allow the value
+        // to be identical for the statistic and test methods.
+        final Hypergeom dist = new Hypergeom(nn, k, m);
+        if (alternative == AlternativeHypothesis.GREATER_THAN) {
+            return dist.sf(a - 1);
+        } else if (alternative == AlternativeHypothesis.LESS_THAN) {
+            return dist.cdf(a);
+        }
+        // two-sided: Find all i where Pr(X = i) <= Pr(X = a) and sum them.
+        return statisticBoschlooTwoSided(dist, a);
+    }
+
+    /**
+     * Compute the two-sided statistic using Fisher's p-value (also known as Boschloo's test).
+     *
+     * @param distribution Hypergeometric distribution.
+     * @param k Observed value.
+     * @return p-value
+     */
+    private static double statisticBoschlooTwoSided(Hypergeom distribution, int k) {
+        // two-sided: Find all i where Pr(X = i) <= Pr(X = k) and sum them.
+        // Logic is the same as FisherExactTest but using the probability (PMF), which
+        // is cached, rather than the logProbability.
+        final double pk = distribution.pmf(k);
+
+        final int m1 = distribution.getLowerMode();
+        final int m2 = distribution.getUpperMode();
+        if (k < m1) {
+            // Lower half = cdf(k)
+            // Find upper half. As k < lower mode i should never
+            // reach the lower mode based on the probability alone.
+            // Bracket with the upper mode.
+            final int i = Searches.searchDescending(m2, distribution.getSupportUpperBound(), pk,
+                distribution::pmf);
+            return distribution.cdf(k) +
+                   distribution.sf(i - 1);
+        } else if (k > m2) {
+            // Upper half = sf(k - 1)
+            // Find lower half. As k > upper mode i should never
+            // reach the upper mode based on the probability alone.
+            // Bracket with the lower mode.
+            final int i = Searches.searchAscending(distribution.getSupportLowerBound(), m1, pk,
+                distribution::pmf);
+            return distribution.cdf(i) +
+                   distribution.sf(k - 1);
+        }
+        // k == mode
+        // Edge case where the sum of probabilities will be either
+        // 1 or 1 - Pr(X = mode) where mode != k
+        final double pm = distribution.pmf(k == m1 ? m2 : m1);
+        return pm > pk ? 1 - pm : 1;
+    }
+
+    /**
+     * Find all tables that are as or more extreme than the observed table using the
+     * Fisher's p-value as the statistic (also known as Boschloo's test).
+     *
+     * @param a Observed value for a.
+     * @param b Observed value for b.
+     * @param m Column sum m.
+     * @param n Column sum n.
+     * @param list List to track more extreme tables.
+     * @return observed p-value
+     */
+    private double findTablesBoschloo(int a, int b, int m, int n, XYList list) {
+        final double statistic = statisticBoschloo(a, b, m, n);
+
+        // Function to compute the statistic
+        BoschlooStatistic func;
+        if (alternative == AlternativeHypothesis.GREATER_THAN) {
+            func = (dist, x) -> dist.sf(x - 1);
+        } else if (alternative == AlternativeHypothesis.LESS_THAN) {
+            func = Hypergeom::cdf;
+        } else {
+            func = UnconditionedExactTest::statisticBoschlooTwoSided;
+        }
+
+        // All tables are: 0 <= i <= m  by  0 <= j <= n
+        // Diagonal (upper-left to lower-right) strips of the possible
+        // tables use the same hypergeometric distribution
+        // (i.e. i+j == number of successes). To enumerate all requires
+        // using the full range of all distributions: 0 <= i+j <= m+n.
+        // Note the column sum m is fixed.
+        final int mn = m + n;
+        for (int k = 0; k <= mn; k++) {
+            final Hypergeom dist = new Hypergeom(mn, k, m);
+            final int lo = dist.getSupportLowerBound();
+            final int hi = dist.getSupportUpperBound();
+            for (int i = lo; i <= hi; i++) {
+                if (func.value(dist, i) <= statistic) {
+                    // j = k - i
+                    list.add(i, k - i);
+                }
+            }
+        }
+        return statistic;
+    }
+
+    /**
+     * Compute the nuisance parameter and p-value for the binomial model given the list
+     * of possible tables.
+     *
+     * <p>The current method enumerates an initial set of points and stores local
+     * extrema as candidates. Any candidate within 2% of the best is optionally
+     * optimized; this is limited to the top 3 candidates. These settings
+     * could be exposed as configurable options. Currently only the choice to optimize
+     * or not is exposed.
+     *
+     * @param list List of tables.
+     * @return [nuisance parameter, p-value]
+     */
+    private double[] computePValue(XYList list) {
+        final DoubleUnaryOperator func = createBinomialModel(list);
+
+        // Enumerate the range [LOWER, 1-LOWER] and save the best points for optimization
+        final Candidates minima = new Candidates(MAX_CANDIDATES, MINIMA_EPS);
+        final int n = points - 1;
+        final double inc = (1.0 - 2 * LOWER_BOUND) / n;
+        // Moving window of 3 values to identify minima.
+        // px holds the position of the previous evaluated point.
+        double v2 = 0;
+        double v3 = func.applyAsDouble(LOWER_BOUND);
+        double px = LOWER_BOUND;
+        for (int i = 1; i < n; i++) {
+            final double x = LOWER_BOUND + i * inc;
+            final double v1 = v2;
+            v2 = v3;
+            v3 = func.applyAsDouble(x);
+            addCandidate(minima, v1, v2, v3, px);
+            px = x;
+        }
+        // Add the upper bound
+        final double x = 1 - LOWER_BOUND;
+        final double vn = func.applyAsDouble(x);
+        addCandidate(minima, v2, v3, vn, px);
+        addCandidate(minima, v3, vn, 0, x);
+
+        final double[] min = minima.getMinimum();
+
+        // Optionally optimize the best point(s) (if not already optimal)
+        if (optimize && min[1] > -1) {
+            final BrentOptimizer opt = new BrentOptimizer(SOLVER_RELATIVE_EPS, Double.MIN_VALUE);
+            final BracketFinder bf = new BracketFinder();
+            minima.forEach(candidate -> {
+                double a = candidate[0];
+                double fa;
+                // Attempt to bracket the minima. Use an initial second point placed relative to
+                // the size of the interval: [x - increment, x + increment].
+                // if a < 0.5 then add a small delta ; otherwise subtract the delta.
+                final double b = a - Math.copySign(inc * INC_FRACTION, a - 0.5);
+                if (bf.search(func, a, b, 0, 1)) {
+                    // The bracket a < b < c must have f(b) < min(f(a), f(b))
+                    final PointValuePair p = opt.optimize(func, bf.getLo(), bf.getHi(), bf.getMid(), bf.getFMid());
+                    a = p.getPoint();
+                    fa = p.getValue();
+                } else {
+                    // Mid-point is at one of the bounds (i.e. is 0 or 1)
+                    a = bf.getMid();
+                    fa = bf.getFMid();
+                }
+                if (fa < min[1]) {
+                    min[0] = a;
+                    min[1] = fa;
+                }
+            });
+        }
+        // Reverse the sign of the p-value to create a maximum.
+        // Note that due to the summation the p-value can be above 1 so we clip the final result.
+        // Note: Apply max then reverse sign. This will pass through spurious NaN values if
+        // the p-value computation produced all NaNs.
+        min[1] = -Math.max(-1, min[1]);
+        return min;
+    }
+
+    /**
+     * Creates the binomial model p-value function for the nuisance parameter.
+     * Note: This function computes the negative p-value so is suitable for
+     * optimization by a search for a minimum.
+     *
+     * @param list List of tables.
+     * @return the function
+     */
+    private static DoubleUnaryOperator createBinomialModel(XYList list) {
+        final int m = list.getMaxX();
+        final int n = list.getMaxY();
+        final int mn = m + n;
+        // Compute the probability using logs
+        final double[] c = new double[list.size()];
+        final int[] ij = new int[list.size()];
+        final int width = list.getWidth();
+
+        // Compute the log binomial dynamically for a small number of values
+        IntToDoubleFunction binomM;
+        IntToDoubleFunction binomN;
+        if (list.size() < mn) {
+            binomM = k -> LogBinomialCoefficient.value(m, k);
+            binomN = k -> LogBinomialCoefficient.value(n, k);
+        } else {
+            // Pre-compute all values
+            binomM = createLogBinomialCoefficients(m);
+            binomN = m == n ? binomM : createLogBinomialCoefficients(n);
+        }
+
+        // Handle special cases i+j == 0 and i+j == m+n.
+        // These will occur only once, if at all. Mark if they occur.
+        int flag = 0;
+        int j = 0;
+        for (int i = 0; i < c.length; i++) {
+            final int index = list.get(i);
+            final int x = index % width;
+            final int y = index / width;
+            final int xy = x + y;
+            if (xy == 0) {
+                flag |= 1;
+            } else if (xy == mn) {
+                flag |= 2;
+            } else {
+                ij[j] = xy;
+                c[j] = binomM.applyAsDouble(x) + binomN.applyAsDouble(y);
+                j++;
+            }
+        }
+
+        final int size = j;
+        final boolean ij0 = (flag & 1) != 0;
+        final boolean ijmn = (flag & 2) != 0;
+        return pi -> {
+            final double logp = Math.log(pi);
+            final double log1mp = Math.log1p(-pi);
+            double sum = 0;
+            for (int i = 0; i < size; i++) {
+                // binom(m, i) * binom(n, j) * pi^(i+j) * (1-pi)^(m+n-i-j)
+                sum += Math.exp(ij[i] * logp + (mn - ij[i]) * log1mp + c[i]);
+            }
+            // Add the simplified terms where the binomial is 1.0 and one power is x^0 == 1.0.
+            // This avoids 0 * log(x) generating NaN when x is 0 in the case where pi was 0 or 1.
+            // Reuse exp (not pow) to support pi approaching 0 or 1.
+            if (ij0) {
+                // pow(1-pi, mn)
+                sum += Math.exp(mn * log1mp);
+            }
+            if (ijmn) {
+                // pow(pi, mn)
+                sum += Math.exp(mn * logp);
+            }
+            // The optimizer minimises the function so this returns -p.
+            return -sum;
+        };
+    }
+
+    /**
+     * Create the natural logarithm of the binomial coefficient for all {@code k = [0, n]}.
+     *
+     * @param n Limit N.
+     * @return ln binom(n, k)
+     */
+    private static IntToDoubleFunction createLogBinomialCoefficients(int n) {
+        final double[] binom = new double[n + 1];
+        // Exploit symmetry.
+        // ignore: binom(n, 0) == binom(n, n) == 1
+        int j = n - 1;
+        for (int i = 1; i <= j; i++, j--) {
+            binom[i] = binom[j] = LogBinomialCoefficient.value(n, i);
+        }
+        return k -> binom[k];
+    }
+
+    /**
+     * Add point 2 to the list of minima if neither neighbour value is lower.
+     * <pre>
+     * !(v1 < v2 || v3 < v2)
+     * </pre>
+     *
+     * @param minima Candidate minima.
+     * @param v1 First point function value.
+     * @param v2 Second point function value.
+     * @param v3 Third point function value.
+     * @param x2 Second point.
+     */
+    private void addCandidate(Candidates minima, double v1, double v2, double v3, double x2) {
+        final double min = v1 < v3 ? v1 : v3;
+        if (min < v2) {
+            // Lower neighbour(s)
+            return;
+        }
+        // Add the candidate. This could be NaN but the candidate list handles this by storing
+        // NaN only when no non-NaN values have been observed.
+        minima.add(x2, v2);
+    }
+
+    /**
+     * Check the input is a 2-by-2 contingency table.
+     *
+     * @param table Table.
+     * @throws IllegalArgumentException if the {@code table} is not a 2-by-2 table; any
+     * table entry is negative; any column sum is zero; the table sum is zero or not an
+     * integer; or the number of possible tables exceeds the maximum array capacity.
+     */
+    private static void checkTable(int[][] table) {
+        Arguments.checkTable(table);
+        // Must all be positive
+        final int a = table[0][0];
+        final int c = table[1][0];
+        // checkTable has validated the total sum is < 2^31
+        final int m = a + c;
+        if (m == 0) {
+            throw new InferenceException(InferenceException.ZERO_AT, COLUMN_SUM, 0);
+        }
+        final int b = table[0][1];
+        final int d = table[1][1];
+        final int n = b + d;
+        if (n == 0) {
+            throw new InferenceException(InferenceException.ZERO_AT, COLUMN_SUM, 1);
+        }
+        // Total possible tables must be a size we can track in an array (to compute the p-value)
+        final long size = (m + 1L) * (n + 1L);
+        if (size > MAX_TABLES) {
+            throw new InferenceException(InferenceException.X_GT_Y, size, MAX_TABLES);
+        }
+    }
+}

--- a/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/BracketFinderTest.java
+++ b/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/BracketFinderTest.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import java.util.function.DoubleUnaryOperator;
+import org.apache.commons.math3.analysis.interpolation.SplineInterpolator;
+import org.apache.commons.math3.analysis.polynomials.PolynomialSplineFunction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test for {@link BracketFinder}.
+ */
+class BracketFinderTest {
+    /** Golden section. */
+    private static final double GOLD = 1.6180339887498948482;
+
+    @Test
+    void testConstructorThrows() {
+        // Input arguments must be strictly positive
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new BracketFinder(0, 10));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new BracketFinder(10, 0));
+    }
+
+    @Test
+    void testMaxEvaluationsThrows() {
+        final DoubleUnaryOperator func = x -> x * x;
+        final BracketFinder bFind = new BracketFinder(100, 2);
+        Assertions.assertThrows(IllegalStateException.class, () -> bFind.search(func, -1, 1, 0, 0));
+    }
+
+    @Test
+    void testCubicMin() {
+        final DoubleUnaryOperator func = new DoubleUnaryOperator() {
+            @Override
+            public double applyAsDouble(double x) {
+                if (x < -2) {
+                    return applyAsDouble(-2);
+                }
+                return (x - 1) * (x + 2) * (x + 3);
+            }
+        };
+        final BracketFinder bFind = new BracketFinder();
+
+        assertBracket(func, bFind,  -2, -1);
+        final double tol = 1e-15;
+        // Comparing with results computed in Python.
+        Assertions.assertEquals(-2, bFind.getLo());
+        Assertions.assertEquals(-1, bFind.getMid());
+        // This value is from a single step using the golden ratio
+        Assertions.assertEquals(GOLD - 1, bFind.getHi(), tol);
+        Assertions.assertEquals(3, bFind.getEvaluations());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "-1, 1",
+        "1, -1",
+        "1, 2",
+        "2, 1",
+    })
+    void testIntervalBoundsOrdering(int lo, int hi) {
+        final DoubleUnaryOperator func = x -> x * x;
+        final BracketFinder bFind = new BracketFinder();
+
+        assertBracket(func, bFind, lo, hi);
+        Assertions.assertTrue(bFind.getLo() <= 0);
+        Assertions.assertTrue(0 <= bFind.getHi());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "-1, 1, 0, 0",
+        "0, 1, 0, 0",
+        "-1, 0, 0, 0",
+        "-1, 1, -10, 10",
+        "0, 1, -10, 10",
+        "-1, 0, -10, 10",
+        // Original points do not bracket the minimum
+        "1, 2, -10, 10",
+        "-2, -1, -10, 10",
+        "5, 6, -10, 10",
+        "-6, -5, -10, 10",
+        // Bounds at the minimum
+        "1, 2, 0, 10",
+        "-2, -1, -10, 0",
+        // Bounds prevent bracketing a minimum
+        "5, 6, 1, 10",
+        // Original points at the bounds
+        "1, 2, 1, 10",
+        "-2, -1, -10, -1",
+        // 1 original point outside at the bounds
+        "5, 20, -1, 10",
+        "-20, -5, -10, 1",
+    })
+    void testXSquared(double a, double b, double min, double max) {
+        final DoubleUnaryOperator func = x -> x * x;
+        // Limit max evaluations for this test
+        final BracketFinder bFind = new BracketFinder(100, 100);
+        assertBracket(func, bFind, a, b, min, max);
+    }
+
+    @Test
+    void testSpline1() {
+        // First three points (a, b, c) of the BracketFinder create lower function values.
+        // The parabolic fit of the points creates a value such that:
+        // a < b < w < c
+        // Use a spline node to force f(w) > f(b) and the minima is in [a, w].
+        final double gold = GOLD;
+        // a=-1, b=0, c=gold
+        final double[] x = {-1, 0, gold / 2, gold};
+        final double[] y = {1, 0, 1, -0.01};
+        final PolynomialSplineFunction f = new SplineInterpolator().interpolate(x, y);
+        final DoubleUnaryOperator func = f::value;
+        final BracketFinder bFind = new BracketFinder();
+        assertBracket(func, bFind, -1, 0);
+        // Check that the bracket is found on the first iteration
+        Assertions.assertEquals(-1, bFind.getLo());
+        Assertions.assertEquals(0, bFind.getMid());
+        Assertions.assertTrue(bFind.getHi() < gold);
+    }
+
+    @Test
+    void testSpline2() {
+        // First three points (a, b, c) of the BracketFinder create lower function values.
+        // The parabolic fit of the points creates a value such that:
+        // a < b < w < c
+        // Use a spline node to force f(b) < f(w) < f(c) and the BracketFinder takes
+        // a default step.
+        final double gold = GOLD;
+        // a=-1, b=0, c=gold
+        final double[] x = {-1, 0, gold / 2, gold, 3, 4, 5};
+        final double[] y = {1, 0, -0.005, -0.01, 1, 2, 3};
+        final PolynomialSplineFunction f = new SplineInterpolator().interpolate(x, y);
+        final DoubleUnaryOperator func = f::value;
+        final BracketFinder bFind = new BracketFinder();
+        assertBracket(func, bFind, -1, 0);
+        // Here the bracket should advance the points on the first iteration
+        // and terminate on the second
+        Assertions.assertEquals(0, bFind.getLo());
+        Assertions.assertEquals(gold, bFind.getMid(), 1e-15);
+        Assertions.assertTrue(bFind.getHi() < 5);
+    }
+
+    @Test
+    void testSpline3() {
+        // First three points (a, b, c) of the BracketFinder create lower function values.
+        // The parabolic fit of the points creates a value such that:
+        // a < b < c < w < limit
+        // Use a spline node to force f(w) > f(c) and the BracketFinder takes terminates
+        // on the first iteration.
+        final double gold = GOLD;
+        // a=-1, b=0, c=gold
+        // First 3 points are parabola: f(x) = (x-gold-0.5)^2, then really steep
+        final double[] x = {-1, 0, gold, 2, 5};
+        final double[] y = {9.7221359549995796, 4.4860679774997898, 0.25, 10, 100};
+        final PolynomialSplineFunction f = new SplineInterpolator().interpolate(x, y);
+        final DoubleUnaryOperator func = f::value;
+        final BracketFinder bFind = new BracketFinder();
+        assertBracket(func, bFind, -1, 0);
+        // Here the bracket should advance the points on the first iteration
+        // and terminate
+        Assertions.assertEquals(0, bFind.getLo());
+        Assertions.assertEquals(gold, bFind.getMid(), 1e-15);
+        Assertions.assertTrue(bFind.getHi() < 5);
+    }
+
+    @Test
+    void testParabolicMinimum() {
+        // The parabolic fit of the points creates a value such that:
+        // c == w (exact minimum).
+        // The BracketFinder ignores this point and takes a default step.
+        final double gold = GOLD;
+        final DoubleUnaryOperator func = x -> x * x;
+        final BracketFinder bFind = new BracketFinder();
+        assertBracket(func, bFind, -gold - 1, -gold);
+        // Here the bracket should advance the points on the first iteration
+        // and terminate
+        Assertions.assertEquals(-gold, bFind.getLo());
+        Assertions.assertEquals(0, bFind.getMid(), 1e-15);
+        Assertions.assertTrue(bFind.getHi() < 5);
+    }
+
+    /**
+     * Assert the bracket surrounds a minima.
+     *
+     * @param func Function to bracket.
+     * @param bFind Bracket finder.
+     */
+    private static void assertBracket(DoubleUnaryOperator func, final BracketFinder bFind,
+                                      double a, double b) {
+        assertBracket(func, bFind, a, b, 0, 0);
+    }
+
+    /**
+     * Assert the bracket surrounds a minima.
+     *
+     * @param func Function to bracket.
+     * @param bFind Bracket finder.
+     * @param a Initial point.
+     * @param b Initial point.
+     * @param min Minimum bound of the bracket (inclusive).
+     * @param max Maximum bound of the bracket (inclusive).
+     */
+    private static void assertBracket(DoubleUnaryOperator func, final BracketFinder bFind,
+                                      double a, double b,
+                                      double min, double max) {
+        final boolean result = bFind.search(func, a, b, min, max);
+        Assertions.assertEquals(func.applyAsDouble(bFind.getLo()), bFind.getFLo(), "f(lo)");
+        Assertions.assertEquals(func.applyAsDouble(bFind.getMid()), bFind.getFMid(), "f(mid)");
+        Assertions.assertEquals(func.applyAsDouble(bFind.getHi()), bFind.getFHi(), "f(hi)");
+        Assertions.assertTrue(bFind.getLo() <= bFind.getMid(), "lo > mid");
+        Assertions.assertTrue(bFind.getMid() <= bFind.getHi(), "hi < mid");
+        Assertions.assertTrue(bFind.getFMid() <= bFind.getFLo(), "f(lo) < f(mid)");
+        Assertions.assertTrue(bFind.getFMid() <= bFind.getFHi(), "f(hi) < f(mid)");
+        Assertions.assertEquals(bFind.getMid() > bFind.getLo() && bFind.getMid() < bFind.getHi(), result, "middle within [lo, hi] interval");
+        if (min < max) {
+            Assertions.assertTrue(min <= bFind.getLo(), "lo < min");
+            Assertions.assertTrue(max >= bFind.getHi(), "hi > max");
+        }
+    }
+}

--- a/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/BrentOptimizerTest.java
+++ b/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/BrentOptimizerTest.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.DoubleUnaryOperator;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import org.apache.commons.statistics.inference.BrentOptimizer.PointValuePair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Test cases for {@link BrentOptimizer}.
+ */
+final class BrentOptimizerTest {
+    /** Minimum relative epsilon used by the solver. */
+    private static final double MIN_REL = 2 * Math.ulp(1.0);
+    /** Minimum absolute epsilon used by the solver. */
+    private static final double MIN_ABS = Double.MIN_VALUE;
+
+    @Test
+    void testInvalidThresholdsThrows() {
+        Assertions.assertDoesNotThrow(() -> new BrentOptimizer(MIN_REL, MIN_ABS));
+        final double rel = Math.nextDown(MIN_REL);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new BrentOptimizer(rel, MIN_ABS));
+        final double abs = Math.nextDown(MIN_ABS);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new BrentOptimizer(MIN_REL, abs));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new BrentOptimizer(Double.NaN, MIN_ABS));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new BrentOptimizer(MIN_REL, Double.NaN));
+    }
+
+    @Test
+    void testInvalidBracketThrows() {
+        BrentOptimizer optimizer = new BrentOptimizer(MIN_REL, MIN_ABS);
+        final DoubleUnaryOperator f = Math::sin;
+        final double x = 0;
+        final double fx = f.applyAsDouble(x);
+        Assertions.assertDoesNotThrow(() -> optimizer.optimize(f, 0, 2 * Double.MIN_VALUE, Double.MIN_VALUE, 0), "smallest bracket");
+        Assertions.assertDoesNotThrow(() -> optimizer.optimize(f, 2 * Double.MIN_VALUE, 0, Double.MIN_VALUE, 0), "smallest bracket");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x, x, x, fx), "no bracket");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x + 0.5, x + 1, x, fx), "start < lo");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x, x + 1, x, fx), "start == lo");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x - 1, x - 0.5, x, fx), "start > hi");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x - 1, x, x, fx), "start == hi");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, Double.NaN, 1, x, fx), "lo == NaN");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x - 1, Double.NaN, x, fx), "hi == NaN");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(f, x - 1, x + 1, Double.NaN, fx), "start == NaN");
+        // The optimizer is robust to NaN function evaluations
+        Assertions.assertDoesNotThrow(() -> optimizer.optimize(f, -1, 1, x, Double.NaN), "f(start) == NaN");
+    }
+
+    /**
+     * Test the optimizer is insensitive to NaN. It will eventually terminate due to
+     * golden section steps.
+     */
+    @ParameterizedTest
+    @ValueSource(doubles = {1, 0.75, 0.5, 0.1})
+    void testNaN(double prob) {
+        // Generate NaNs with the given probability
+        final DoubleUnaryOperator f = x -> ThreadLocalRandom.current().nextDouble() < prob ? Double.NaN : 1;
+        final BrentOptimizer optimizer = new BrentOptimizer(MIN_REL, MIN_ABS);
+
+        final double a = 1.53;
+        final double b = a + Math.ulp(a) * 100000;
+        for (int i = 0; i < 5; i++) {
+            final PointValuePair p = optimize(optimizer, f, a, b);
+            Assertions.assertTrue(a < p.getPoint() && p.getPoint() < b);
+        }
+    }
+
+    @Test
+    void testSinMin() {
+        final DoubleUnaryOperator f = Math::sin;
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-14);
+
+        // Note: It is not possible to get the exact answer as sin(x) == -1 over a range of x.
+        PointValuePair p = optimize(optimizer, f, 4, 5);
+        TestUtils.assertRelativelyEquals(3 * Math.PI / 2, p.getPoint(), 5e-12, "(4, 5)");
+        Assertions.assertEquals(-1, p.getValue(), "(4, 5)");
+
+        p = optimize(optimizer, f, 1, 5);
+        TestUtils.assertRelativelyEquals(3 * Math.PI / 2, p.getPoint(), 5e-12, "(1, 5)");
+        Assertions.assertEquals(-1, p.getValue(), "(1, 5)");
+
+        Assertions.assertTrue(optimizer.getEvaluations() <= 100);
+        Assertions.assertTrue(optimizer.getEvaluations() >= 15);
+
+        // Verify that the argument order for the interval does not matter
+        p = optimize(optimizer, f, 5, 1);
+        TestUtils.assertRelativelyEquals(3 * Math.PI / 2, p.getPoint(), 5e-12, "(1, 5)");
+        Assertions.assertEquals(-1, p.getValue(), "(1, 5)");
+    }
+
+    @Test
+    void testBoundaries() {
+        final double lower = -1.0;
+        final double upper = +1.0;
+        final DoubleUnaryOperator f = x -> {
+            if (x < lower) {
+                Assertions.fail("too small: " + x);
+            } else if (x > upper) {
+                Assertions.fail("too large: " + x);
+            }
+            return x;
+        };
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-14);
+        Assertions.assertEquals(lower, optimize(optimizer, f, lower, upper).getPoint(), 1.0e-8);
+    }
+
+    @Test
+    void testQuinticMin() {
+        // The function has local minima at -0.27195613 and 0.82221643.
+        final DoubleUnaryOperator f = quinticFunction();
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-14);
+        Assertions.assertEquals(-0.27195613, optimize(optimizer, f, -0.3, -0.2).getPoint(), 1.0e-8);
+        Assertions.assertEquals(0.82221643, optimize(optimizer, f, 0.3, 0.9).getPoint(), 1.0e-8);
+        Assertions.assertTrue(optimizer.getEvaluations() <= 50);
+
+        // search in a large interval
+        Assertions.assertEquals(-0.27195613, optimize(optimizer, f, -1.0, 0.2).getPoint(), 1.0e-8);
+    }
+
+    @Test
+    void testQuinticMinStatistics() {
+        final DoubleUnaryOperator f = quinticFunction();
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-11, 1e-14);
+
+        final DoubleStream.Builder optValue = DoubleStream.builder();
+        final IntStream.Builder eval = IntStream.builder();
+
+        // The function has local minima at -0.27195613.
+        final double min = -0.75;
+        final double max = 0.25;
+        final int nSamples = 200;
+        final double delta = (max - min) / (nSamples + 1);
+        for (int i = 1; i <= nSamples; i++) {
+            final double start = min + i * delta;
+            optValue.add(optimizer.optimize(f, min, max, start, f.applyAsDouble(start)).getPoint());
+            eval.add(optimizer.getEvaluations());
+        }
+
+        final double meanOptValue = optValue.build().average().getAsDouble();
+        Assertions.assertTrue(meanOptValue > -0.2719561281);
+        Assertions.assertTrue(meanOptValue < -0.2719561280);
+        int[] vals = eval.build().sorted().toArray();
+        final double median = (vals[nSamples / 2] + vals[(nSamples + 1) / 2]) * 0.5;
+        Assertions.assertEquals(21, median);
+    }
+
+    @Test
+    void testQuinticMax() {
+        // The quintic function has zeros at 0, +-0.5 and +-1.
+        // The function has a local maximum at 0.27195613.
+        final DoubleUnaryOperator f = quinticFunction().andThen(x -> -x);
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-12, 1e-14);
+        Assertions.assertEquals(0.27195613, optimize(optimizer, f, 0.2, 0.3).getPoint(), 1e-8);
+    }
+
+    @Test
+    void testMinEndpoints() {
+        final DoubleUnaryOperator f = Math::sin;
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-14);
+
+        // endpoint is minimum
+        PointValuePair p = optimize(optimizer, f, 3 * Math.PI / 2, 5);
+        TestUtils.assertRelativelyEquals(3 * Math.PI / 2, p.getPoint(), 1e-8, "(x, 5)");
+        Assertions.assertEquals(-1, p.getValue());
+
+        p = optimize(optimizer, f, 4, 3 * Math.PI / 2);
+        TestUtils.assertRelativelyEquals(3 * Math.PI / 2, p.getPoint(), 1e-8, "(4, x)");
+        Assertions.assertEquals(-1, p.getValue());
+    }
+
+    @Test
+    void testMath832() {
+        final DoubleUnaryOperator f = x -> {
+            final double sqrtX = Math.sqrt(x);
+            final double a = 1e2 * sqrtX;
+            final double b = 1e6 / x;
+            final double c = 1e4 / sqrtX;
+            return a + b + c;
+        };
+
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-8);
+        final double result = optimize(optimizer, f, Double.MIN_VALUE, Double.MAX_VALUE).getPoint();
+
+        Assertions.assertEquals(804.9355825, result, 1e-6);
+    }
+
+    /**
+     * Contrived example showing that prior to the resolution of MATH-855
+     * (second revision), the algorithm would not return the best point if
+     * it happened to be the initial guess.
+     */
+    @Test
+    void testKeepInitIfBest() {
+        final double minSin = 3 * Math.PI / 2;
+        final double offset = 1e-8;
+        final double delta = 1e-7;
+        final DoubleUnaryOperator f1 = Math::sin;
+        final DoubleUnaryOperator f2 = new StepFunction(new double[] {minSin, minSin + offset, minSin + 2 * offset},
+                                                        new double[] {0, -1, 0});
+        final DoubleUnaryOperator f = x -> f1.applyAsDouble(x) + f2.applyAsDouble(x);
+        // A slightly less stringent tolerance would make the test pass
+        // even with the previous implementation.
+        final double relTol = 1e-8;
+        final BrentOptimizer optimizer = new BrentOptimizer(relTol, 1e-100);
+        final double init = minSin + 1.5 * offset;
+        final PointValuePair result
+            = optimizer.optimize(f, minSin - 6.789 * delta,
+                                    minSin + 9.876 * delta,
+                                    init, f.applyAsDouble(init));
+
+        final double sol = result.getPoint();
+        final double expected = init;
+
+//        TestUtils.printf("numEval=%d%n", optimizer.getEvaluations());
+//        TestUtils.printf("min=%s f=%s%n", init, f.applyAsDouble(init));
+//        TestUtils.printf("sol=%s f=%s%n", sol, f.applyAsDouble(sol));
+//        TestUtils.printf("exp=%s f=%s%n", expected, f.applyAsDouble(expected));
+
+        Assertions.assertTrue(f.applyAsDouble(sol) <= f.applyAsDouble(expected), "Best point not reported");
+    }
+
+    /**
+     * Contrived example showing that prior to the resolution of MATH-855,
+     * the algorithm, by always returning the last evaluated point, would
+     * sometimes not report the best point it had found.
+     */
+    @Test
+    void testMath855() {
+        final double minSin = 3 * Math.PI / 2;
+        final double offset = 1e-8;
+        final double delta = 1e-7;
+        final DoubleUnaryOperator f1 = Math::sin;
+        final DoubleUnaryOperator f2 = new StepFunction(new double[] {minSin, minSin + offset, minSin + 5 * offset},
+                                                        new double[] {0, -1, 0});
+        final DoubleUnaryOperator f = x -> f1.applyAsDouble(x) + f2.applyAsDouble(x);
+        final BrentOptimizer optimizer = new BrentOptimizer(1e-8, 1e-100);
+        final PointValuePair result
+            = optimize(optimizer, f, minSin - 6.789 * delta,
+                                     minSin + 9.876 * delta);
+
+        final double sol = result.getPoint();
+        // Note:
+        // This value may have been extracted from print statements within the BrentOptimizer.
+        // It is the second to last point evaluated before convergence. The last two
+        // function evaluations are -1.999999999999999 and -0.9999999999999956. The test thus
+        // verifies that the best point is returned, not the latest.
+        final double expected = 4.712389027602411;
+
+        Assertions.assertTrue(f.applyAsDouble(sol) <= f.applyAsDouble(expected), "Best point not reported");
+    }
+
+    /**
+     * Optimize the function using the optimizer. The start point is evaluated as the middle of
+     * the provided bounds.
+     *
+     * @param optimizer Optimizer.
+     * @param func Function.
+     * @param a Lower bound (exclusive).
+     * @param b Upper bound (exclusive).
+     * @return the point value pair
+     */
+    private static PointValuePair optimize(BrentOptimizer optimizer, DoubleUnaryOperator func, double a, double b) {
+        final double x = 0.5 * (a + b);
+        return optimizer.optimize(func, a, b, x, func.applyAsDouble(x));
+    }
+
+    @Test
+    void testQuintic() {
+        final DoubleUnaryOperator func = quinticFunction();
+        Assertions.assertEquals(0.0, func.applyAsDouble(0));
+        Assertions.assertEquals(-0.0, func.applyAsDouble(0.5));
+        Assertions.assertEquals(0.0, func.applyAsDouble(1));
+        // Note: These are the result of a simple bisection search that
+        // does not handle detection of a maxima in the bracket (a, b)
+        Assertions.assertEquals(-0.27195612937209723, findMin(func, -0.3, -0.25));
+        Assertions.assertEquals(0.8222164338827133, findMin(func, 0.8, 0.84));
+        Assertions.assertEquals(0.2719561271718704, findMin(func.andThen(x -> -x), 0.25, 0.3));
+    }
+
+    /**
+     * Find the min of the function using a simple bisection search that maintains the
+     * two lowest points of the half interval.
+     *
+     * @param func Function
+     * @param a Lower bound
+     * @param b Upper bound
+     * @return the min
+     */
+    private static double findMin(DoubleUnaryOperator func, double a, double b) {
+        double fa = func.applyAsDouble(a);
+        double fb = func.applyAsDouble(b);
+        while (a + Math.ulp(a) < b) {
+            final double x = 0.5 * (a + b);
+            final double f = func.applyAsDouble(x);
+            // Three cases
+            // 1. Lower than min(fa, fb)
+            // - Discard highest point
+            // 2. Lower than max(fa, fb)
+            // - Discard highest point
+            // 3. Higher than max(fa, fb)
+            // - The bracket a,b contains a maxima. Assume floating point error and
+            //   discard the highest point.
+
+            // Discard the highest point
+            if (fa > fb) {
+                fa = f;
+                a = x;
+            } else {
+                fb = f;
+                b = x;
+            }
+        }
+        return fa < fb ? a : b;
+    }
+
+    /**
+     * Create the quintic function.
+     * The function has local minima at -0.27195613 and 0.82221643.
+     * The function has zeros at 0, +-0.5 and +-1.
+     * The function has a local maximum at 0.27195613.
+     *
+     * @return the function
+     */
+    private static DoubleUnaryOperator quinticFunction() {
+        return x -> (x - 1) * (x - 0.5) * x * (x + 0.5) * (x + 1);
+    }
+
+    /**
+     * <a href="http://en.wikipedia.org/wiki/Step_function">Step function</a>.
+     */
+    static class StepFunction implements DoubleUnaryOperator {
+        /** Abscissae. */
+        private final double[] abscissa;
+        /** Ordinates. */
+        private final double[] ordinate;
+
+        /**
+         * Builds a step function from a list of arguments and the corresponding
+         * values. Specifically, returns the function h(x) defined by <pre><code>
+         * h(x) = y[0] for all x &lt; x[1]
+         *        y[1] for x[1] &le; x &lt; x[2]
+         *        ...
+         *        y[y.length - 1] for x &ge; x[x.length - 1]
+         * </code></pre>
+         * The value of {@code x[0]} is ignored, but it must be strictly less than
+         * {@code x[1]}.
+         *
+         * <p>The input x and y are assumed to satisfy the condition where x is sorted
+         * and y is the same length as x.
+         *
+         * @param x Domain values where the function changes value.
+         * @param y Values of the function.
+         */
+        StepFunction(double[] x, double[] y) {
+            // No argument checks. Store arrays directly.
+            abscissa = x;
+            ordinate = y;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public double applyAsDouble(double x) {
+            final int index = Arrays.binarySearch(abscissa, x);
+            double fx = 0;
+
+            if (index < -1) {
+                // "x" is between "abscissa[-index-2]" and "abscissa[-index-1]".
+                fx = ordinate[-index - 2];
+            } else if (index >= 0) {
+                // "x" is exactly "abscissa[index]".
+                fx = ordinate[index];
+            } else {
+                // Otherwise, "x" is smaller than the first value in "abscissa"
+                // (hence the returned value should be "ordinate[0]").
+                fx = ordinate[0];
+            }
+
+            return fx;
+        }
+    }
+}

--- a/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/FisherExactTestTest.java
+++ b/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/FisherExactTestTest.java
@@ -145,23 +145,10 @@ class FisherExactTestTest {
 
     /**
      * Test the p-value at the mode.
-     * See also Math-1644 which is relevant to the same situation in the BinomialTest
+     * See also Math-1644 which is relevant to the same situation in the BinomialTest.
      */
     @ParameterizedTest
-    @CsvSource({
-        // k = mode = ceil((n+1)(K+1) / (N+2)) - 1, floor((n+1)(K+1) / (N+2))
-        // Exact mode
-        "2, 2, 7, 1",
-        "4, 3, 8, 2",
-        // Rounded
-        "2, 2, 5, 1",
-        "2, 2, 5, 2",
-        "4, 3, 10, 1",
-        "4, 3, 10, 2",
-        // mode == 1.5
-        "4, 2, 8, 1",
-        "4, 2, 8, 2",
-    })
+    @MethodSource
     void testMode(int n, int kk, int nn, int k) {
         final int[][] table = {
             {k, kk - k},
@@ -169,6 +156,23 @@ class FisherExactTestTest {
         };
         final double pval = FisherExactTest.withDefaults().test(table).getPValue();
         Assertions.assertTrue(pval <= 1, () -> "pval=" + pval);
+    }
+
+    static Stream<Arguments> testMode() {
+        final Stream.Builder<Arguments> builder = Stream.builder();
+        // k = mode = ceil((n+1)(K+1) / (N+2)) - 1, floor((n+1)(K+1) / (N+2))
+        // Exact mode
+        builder.add(Arguments.of(2, 2, 7, 1));
+        builder.add(Arguments.of(4, 3, 8, 2));
+        // Rounded
+        builder.add(Arguments.of(2, 2, 5, 1));
+        builder.add(Arguments.of(2, 2, 5, 2));
+        builder.add(Arguments.of(4, 3, 10, 1));
+        builder.add(Arguments.of(4, 3, 10, 2));
+        // mode == 1.5
+        builder.add(Arguments.of(4, 2, 8, 1));
+        builder.add(Arguments.of(4, 2, 8, 2));
+        return builder.build();
     }
 
     @ParameterizedTest

--- a/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/HypergeomTest.java
+++ b/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/HypergeomTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import org.apache.commons.statistics.distribution.HypergeometricDistribution;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test cases for {@link Hypergeom}.
+ *
+ * <p>This verifies the cache of the hypergeometric distribution is used to compute the same
+ * probability values as the underlying {@link HypergeometricDistribution}.
+ */
+class HypergeomTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "10, 5, 5",
+        "10, 3, 5",
+        "12, 5, 3",
+    })
+    void testDistribution(int n, int k, int m) {
+        final HypergeometricDistribution d1 = HypergeometricDistribution.of(n, k, m);
+        final Hypergeom d2 = new Hypergeom(n, k, m);
+        final int lo = d1.getSupportLowerBound();
+        final int hi = d2.getSupportUpperBound();
+        Assertions.assertEquals(lo, d2.getSupportLowerBound(), "lower bound");
+        Assertions.assertEquals(hi, d2.getSupportUpperBound(), "upper bound");
+        // Out of bounds will throw
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> d2.pmf(-1), "pmf(-1)");
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> d2.pmf(hi + 1), "pmf(hi + 1)");
+        // Out of bounds for the cumulative functions is supported
+        Assertions.assertEquals(d1.cumulativeProbability(lo - 1), d2.cdf(lo - 1), "cdf(lo - 1)");
+        Assertions.assertEquals(d1.cumulativeProbability(hi + 1), d2.cdf(hi + 1), "cdf(hi + 1)");
+        Assertions.assertEquals(d1.survivalProbability(lo - 1), d2.sf(lo - 1), "sf(lo - 1)");
+        Assertions.assertEquals(d1.survivalProbability(hi + 1), d2.sf(hi + 1), "sf(hi + 1)");
+        for (int x = lo; x <= hi; x++) {
+            Assertions.assertEquals(d1.probability(x), d2.pmf(x), "pmf");
+            Assertions.assertEquals(d1.cumulativeProbability(x), d2.cdf(x), "cdf");
+            Assertions.assertEquals(d1.survivalProbability(x), d2.sf(x), "sf");
+        }
+        // Test the mode is the highest pmf
+        double p = d2.pmf(lo);
+        for (int x = lo + 1;; x++) {
+            final double p2 = d2.pmf(x);
+            if (p2 > p) {
+                p = p2;
+            } else {
+                Assertions.assertEquals(d2.getLowerMode(), x - 1, "lower mode");
+                break;
+            }
+        }
+        p = d2.pmf(hi);
+        for (int x = hi - 1;; x--) {
+            final double p2 = d2.pmf(x);
+            if (p2 > p) {
+                p = p2;
+            } else {
+                Assertions.assertEquals(d2.getUpperMode(), x + 1, "upper mode");
+                break;
+            }
+        }
+    }
+}

--- a/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/UnconditionedExactTestTest.java
+++ b/commons-statistics-inference/src/test/java/org/apache/commons/statistics/inference/UnconditionedExactTestTest.java
@@ -1,0 +1,624 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.statistics.inference;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.SplittableRandom;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.commons.statistics.inference.UnconditionedExactTest.Candidates;
+import org.apache.commons.statistics.inference.UnconditionedExactTest.Method;
+import org.apache.commons.statistics.inference.UnconditionedExactTest.Result;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Test cases for {@link UnconditionedExactTest}.
+ */
+class UnconditionedExactTestTest {
+
+    /**
+     * Test the candidates data structure expands as expected. This test ensures the
+     * structure can store multiple minima within tolerance of the best minima. It
+     * hits edge case is not reached by current test data cases, such as more than two
+     * minima and more minima than the initial capacity.
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testCandidatesList(int max, double eps, double[][] points, double[][] expected) {
+        final Candidates candidates = new Candidates(max, eps);
+        Assertions.assertNull(candidates.getMinimum(), "min of empty");
+        Arrays.stream(points).forEach(x -> candidates.add(x[0], x[1]));
+        ArrayList<double[]> actual = new ArrayList<>();
+        candidates.forEach(actual::add);
+        Assertions.assertArrayEquals(expected, actual.toArray(new double[0][0]), "forEach candidates");
+        // Check the min
+        Optional<double[]> min = Arrays.stream(expected).reduce((x, y) -> x[1] > y[1] ? y : x);
+        Assertions.assertArrayEquals(min.orElseGet(() -> null), candidates.getMinimum(), "min");
+    }
+
+    static Stream<Arguments> testCandidatesList() {
+        final double nan = Double.NaN;
+        final double inf = Double.POSITIVE_INFINITY;
+        final Stream.Builder<Arguments> builder = Stream.builder();
+        // Add nothing
+        builder.add(Arguments.of(1, 0.05,
+            new double[0][0],
+            new double[0][0]));
+        // Single point
+        builder.add(Arguments.of(1, 0.05,
+            new double[][] {{0, 1}},
+            new double[][] {{0, 1}}));
+        // Multiple values
+        builder.add(Arguments.of(10, 0.05,
+            new double[][] {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}},
+            new double[][] {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}}));
+        // Only store 1 point. Keeps the last encountered (by replacement)
+        builder.add(Arguments.of(1, 0.05,
+            new double[][] {{0, 1}, {1, 1}},
+            new double[][] {{1, 1}}));
+        // Only store points within 10%
+        builder.add(Arguments.of(10, 0.1,
+            new double[][] {{0, 1}, {1, 1.1}, {2, 1.2}, {3, 1.05}},
+            new double[][] {{0, 1}, {1, 1.1}, {3, 1.05}}));
+        // Only store points within 5% of min encountered
+        builder.add(Arguments.of(10, 0.05,
+            new double[][] {{0, 2}, {1, 1}, {2, 1.2}, {3, 1.05}},
+            new double[][] {{1, 1}, {3, 1.05}}));
+        // Add only NaN - Stores only the first NaN
+        builder.add(Arguments.of(10, 0.05,
+            new double[][] {{0, nan}, {1, nan}, {2, nan}},
+            new double[][] {{0, nan}}));
+        // Add non-NaN and NaN. NaNs are removed as above the relative threshold
+        builder.add(Arguments.of(10, 0.05,
+            new double[][] {{0, nan}, {1, 1.05}, {2, 1.05}},
+            new double[][] {{1, 1.05}, {2, 1.05}}));
+        builder.add(Arguments.of(10, 0.05,
+            new double[][] {{0, 1.05}, {1, nan}, {2, 1.05}},
+            new double[][] {{0, 1.05}, {2, 1.05}}));
+        // No tolerance
+        builder.add(Arguments.of(10, 0,
+            new double[][] {{0, 1}, {1, 1.1}, {2, 0.99}},
+            new double[][] {{2, 0.99}}));
+        // No tolerance. Handles +inf despite inf*0 = NaN
+        builder.add(Arguments.of(10, 0,
+            new double[][] {{0, inf}, {1, inf}},
+            new double[][] {{0, inf}, {1, inf}}));
+        builder.add(Arguments.of(10, 0,
+            new double[][] {{0, inf}, {1, inf}, {2, 1.0e300}},
+            new double[][] {{2, 1.0e300}}));
+        return builder.build();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "10, 3, 0.05",
+        "5, 1, 0.0",
+        "10, 10, 0.1",
+        "10, 10, 0.5",
+    })
+    void testCandidatesListRandom(int n, int max, double eps) {
+        // Use a fixed seed known to avoid generating duplicates
+        final SplittableRandom rng = new SplittableRandom(2374897234780L);
+        double[] v = rng.doubles(n, -1, 0).toArray();
+        double min = Arrays.stream(v).min().getAsDouble();
+        double[][] actual = IntStream.range(0, n)
+            .mapToObj(i -> new double[] {i, v[i]}).toArray(double[][]::new);
+        double threshold = min + eps * Math.abs(min);
+        double[][] expected = IntStream.range(0, n)
+            .filter(i -> v[i] <= threshold)
+            .mapToObj(i -> new double[] {i, v[i]}).limit(n).toArray(double[][]::new);
+        testCandidatesList(max, eps, actual, expected);
+    }
+
+    @Test
+    void testInvalidOptionsThrows() {
+        final UnconditionedExactTest test = UnconditionedExactTest.withDefaults();
+        Assertions.assertThrows(NullPointerException.class, () ->
+            test.with((AlternativeHypothesis) null));
+        Assertions.assertThrows(NullPointerException.class, () ->
+            test.with((Method) null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 0, -1, Integer.MIN_VALUE})
+    void testInvalidInitialPointsThrows(int points) {
+        final UnconditionedExactTest test = UnconditionedExactTest.withDefaults();
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+            test.withInitialPoints(points));
+    }
+
+    @Test
+    void testUnconditionedExactTestInvalidTableThrows() {
+        assertUnconditionedExactTestInvalidTableThrows(UnconditionedExactTest.withDefaults()::statistic);
+        assertUnconditionedExactTestInvalidTableThrows(UnconditionedExactTest.withDefaults()::test);
+    }
+
+    private void assertUnconditionedExactTestInvalidTableThrows(Consumer<int[][]> action) {
+        // Non 2-by-2 input
+        Assertions.assertThrows(IllegalArgumentException.class, () -> action.accept(new int[3][3]));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> action.accept(new int[2][1]));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> action.accept(new int[1][2]));
+        // Non-square input
+        final int[][] v = {{1, 2}, {3}};
+        Assertions.assertThrows(IllegalArgumentException.class, () -> action.accept(v));
+        final int[][] w = {{1}, {2, 3}};
+        Assertions.assertThrows(IllegalArgumentException.class, () -> action.accept(w));
+        // Columns sum is zero
+        final int[][] y = {{0, 1}, {0, 2}};
+        TestUtils.assertThrowsWithMessage(IllegalArgumentException.class,
+            () -> action.accept(y), "column", "sum", "0", "zero");
+        final int[][] z = {{1, 0}, {2, 0}};
+        TestUtils.assertThrowsWithMessage(IllegalArgumentException.class,
+            () -> action.accept(z), "column", "sum", "1", "zero");
+        // Maximum tables (m+1)*(n+1) > max array size
+        final int x = 1 << 16;
+        final int[][] big = {{0, 0}, {x, x}};
+        final long product = (x + 1L) * (x + 1L);
+        TestUtils.assertThrowsWithMessage(IllegalArgumentException.class,
+            () -> action.accept(big), Long.toString(product));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // Sum zero
+        "0, 0, 0, 0",
+        // Negative values
+        "-1, 2, 3, 4",
+        "1, -2, 3, 4",
+        "1, 2, -3, 4",
+        "1, 2, 3, -4",
+        // Overflow (sum not an integer)
+        "2147483647, 1, 0, 0",
+        "2147483647, 0, 1, 0",
+        "2147483647, 0, 0, 1",
+        "2147483647, 2147483647, 0, 0",
+        "2147483647, 0, 2147483647, 0",
+        "2147483647, 0, 0, 2147483647",
+        "2147483647, 0, 2147483647, 2147483647",
+        "2147483647, 2147483647, 0, 2147483647",
+        "2147483647, 2147483647, 2147483647, 2147483647",
+    })
+    void testUnconditionedExactTestThrows(int a, int b, int c, int d) {
+        final int[][] table = {{a, b}, {c, d}};
+        final UnconditionedExactTest test = UnconditionedExactTest.withDefaults();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> test.statistic(table), "statistic");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> test.test(table), "test");
+    }
+
+    /**
+     * Test the p-value at the mode.
+     * Reuses the test cases from the FisherExactTest to ensure the test statistic is
+     * computed correctly.
+     */
+    @ParameterizedTest
+    @MethodSource(value = {"org.apache.commons.statistics.inference.FisherExactTestTest#testMode"})
+    void testMode(int n, int kk, int nn, int k) {
+        final int[][] table = {
+            {k, kk - k},
+            {n - k, nn - (n + kk) + k}
+        };
+        final double pval = FisherExactTest.withDefaults().test(table).getPValue();
+        Assertions.assertEquals(pval, UnconditionedExactTest.withDefaults().statistic(table), "statistic");
+        Assertions.assertEquals(pval, UnconditionedExactTest.withDefaults().test(table).getStatistic(), "test statistic");
+    }
+
+    /**
+     * Test the unconditioned exact test.
+     *
+     * <p>Note that this test involves an optional optimization to find the nuisance
+     * parameter. As such there is some discrepancy between reference implementations in
+     * SciPy and R. For the purpose of this test the number of initial search points has
+     * been matched to the reference implementation where possible to allow a fair
+     * comparison. SciPy uses by default a sobol sequence with a power of 2 number of points.
+     * This generates n points uniformly in the half-open interval [0, 1) using an increment of
+     * 1/n. The R Exact package uses n points uniformly in the range [1e-5, 1 - 1e-5] using
+     * an increment of (1 - 2e-5) / (n-1) as it includes both end points.
+     * <pre>
+     *        lo     hi          inc
+     * SciPy  0      1 - 1/n     1/n
+     * R      1e-5   1 - 1e-5    (1-2e-5)/(n-1)
+     * </pre>
+     *
+     * <p>Note that Barnard's original paper (1947) specifies that the nuisance parameter
+     * is in the open interval (0, 1); thus SciPy's enumeration that includes 0 is
+     * incorrect by this definition. Also note that the optimization routine used by SciPy uses
+     * the closed interval [0, 1] for the bounds. The current Java implementation has been
+     * matched to the R Exact package to enumerate almost the entire range of the open interval
+     * (0, 1). Thus to closely match the 32 default points used by SciPy requires 33 points.
+     *
+     * <p>If the nuisance parameter approaches either 0 or 1 then this edge case table is likely
+     * to generate a p-value close to 1. For significance testing the result of 1.0 or almost
+     * 1.0 does not matter and a lower relative epsilon is used to allow the test to pass.
+     */
+    @ParameterizedTest
+    @MethodSource(value = {"testZPooled", "testZUnpooled", "testBoschloo"})
+    void testUnconditionedExactTest(int a, int b, int c, int d, Method method,
+            int points, boolean optimize, double[] stat, double[] p, double statisticEps, double pEps) {
+        final int[][] table = {{a, b}, {c, d}};
+        UnconditionedExactTest test = UnconditionedExactTest.withDefaults()
+            .with(method).withInitialPoints(points).withOptimize(optimize);
+        double statistic = 0;
+        if (stat.length == 1) {
+            statistic = test.statistic(table);
+            TestUtils.assertRelativelyEquals(stat[0], statistic, statisticEps, "statistic");
+        }
+        int i = 0;
+        for (final AlternativeHypothesis h : AlternativeHypothesis.values()) {
+            test = test.with(h);
+            final SignificanceResult r = test.test(table);
+            if (stat.length != 1) {
+                statistic = test.statistic(table);
+                TestUtils.assertRelativelyEquals(stat[i], statistic, statisticEps, () -> h + " statistic");
+                // Special case where Boschloo's test should use the Fisher exact test p-value
+                if (method == Method.BOSCHLOO) {
+                    Assertions.assertEquals(FisherExactTest.withDefaults().with(h).test(table).getPValue(), statistic,
+                        () -> h + " Fisher p-value");
+                }
+            }
+            Assertions.assertEquals(statistic, r.getStatistic(), () -> h + " statistic mismatch");
+            TestUtils.assertProbability(p[i++], r.getPValue(), pEps, () -> h + " p-value");
+        }
+    }
+
+    static Stream<Arguments> testZPooled() {
+        // p-values are in the AlternativeHypothesis enum order: two-sided, greater, less
+        // statistic is in the same order; or an array of length 1 if the statistic is the
+        // same.
+
+        // Reference data:
+        //
+        // scipy.stats.barnard_exact (version 1.9.3)
+        // barnard_exact([[7, 12], [8, 3]], alternative='greater')
+        //
+        // R: 3.6.1; Exact 3.2.0
+        // require('Exact')
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='z-pooled', alternative='g', npNumbers=33)[c(1,3)]
+
+        // The implementation more closely matches SciPy than R for the z value; the p-value
+        // is dependent on the z computation and also the sum to find the nuisance parameter.
+        // This particularly effects the test without optimization using R as the reference.
+
+        final Stream.Builder<Arguments> builder = Stream.builder();
+        // SciPy
+        builder.add(Arguments.of(7, 12, 8, 3,
+            Method.Z_POOLED, 33, true,
+            new double[] {-1.8943380760602064},
+            new double[] {0.06815343273153582, 1, 0.034076716365767874}, 1e-15, 7e-15));
+        // R without optimization
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='z-pooled', alternative='t', npNumbers=15, ref.pvalue=FALSE)[c(1,3)]
+        builder.add(Arguments.of(7, 12, 8, 3,
+            Method.Z_POOLED, 15, false,
+            new double[] {-1.8943380760599999},
+            new double[] {0.067726937136699999, 1, 0.033863468568400001}, 2e-13, 3e-3));
+
+        builder.add(Arguments.of(8, 2, 1, 5,
+            Method.Z_POOLED, 33, true,
+            new double[] {2.4722801848029503},
+            new double[] {0.021270751953124997, 0.012192436131969697, 1}, 1e-15, 4e-15));
+
+        // SciPy example for Boschloo's test
+        builder.add(Arguments.of(74, 31, 43, 32,
+            Method.Z_POOLED, 33, true,
+            new double[] {1.8225863590257527},
+            // R:         0.070148380863900003, 0.046915929572300001, 1
+            new double[] {0.070148380862763000, 0.04691595404276874, 1}, 1e-15, 2e-13));
+
+        // Larger tables.
+        builder.add(Arguments.of(123, 92, 424, 113,
+            Method.Z_POOLED, 33, true,
+            new double[] {-6.051476769955081},
+            new double[] {9.978753707498542e-09, 1, 9.978753707498542e-09}, 1e-15, 1e-12));
+
+        // These cases have a p-value function with multiple maxima with similar values.
+        // Enumerating the range may identify the wrong candidate to optimize when
+        // the p-values are close. Using an implementation
+        // that optimizes multiple candidates finds the global maximum p-value.
+        // Note: The R implementation appears to only optimize the best candidate. The SciPy
+        // implementation is more robust to multiple similar maxima.
+        // The Java implementation picks the top candidates; all have to be within a tolerance
+        // of the minimum candidate.
+        builder.add(Arguments.of(123, 92, 424, 313,
+            Method.Z_POOLED, 33, true,
+            new double[] {-0.08382278919954203},
+            // R:         1                 , 1, 0.47180327976999997 (33 points)
+            //                                   0.47653831055000001 (100 points)
+            new double[] {0.9480782554147217, 1, 0.4765383214549828}, 1e-15, 1e-12));
+        builder.add(Arguments.of(67, 42, 23, 88,
+            Method.Z_POOLED, 33, true,
+            new double[] {6.145972185362486},
+            // R:         4.8482474012700005e-10, 4.09507656074e-10 (33 points)
+            new double[] {4.8482474013205090e-10, 4.095910401645987e-10, 1}, 1e-15, 1e-13));
+
+        // Edge case: p0 == p1
+        // SciPy allows the nuisance parameter to be zero so computes p = 1.0
+        // R Exact does not and computes p = 0.99986000910299999
+        // The Java implementation computes p = 0.9999999...
+        // To pass the non-exact assertion with 1.0 we use nextDown
+        builder.add(Arguments.of(7, 12, 7, 12,
+            Method.Z_POOLED, 33, true,
+            new double[] {0},
+            new double[] {1, Math.nextDown(1.0), Math.nextDown(1.0)}, 1e-15, 3e-7));
+
+        // Edge case minimum tables.
+        builder.add(Arguments.of(1, 0, 0, 1,
+            Method.Z_POOLED, 33, true,
+            new double[] {1.414213562373095},
+            new double[] {0.5, 0.25, 1}, 1e-15, 1e-15));
+        builder.add(Arguments.of(0, 1, 1, 0,
+            Method.Z_POOLED, 33, true,
+            new double[] {-1.414213562373095},
+            new double[] {0.5, 1, 0.25}, 1e-15, 1e-15));
+        return builder.build();
+    }
+
+    static Stream<Arguments> testZUnpooled() {
+        // p-values are in the AlternativeHypothesis enum order: two-sided, greater, less
+        // statistic is in the same order; or an array of length 1 if the statistic is the
+        // same.
+
+        // Reference data:
+        //
+        // scipy.stats.barnard_exact (version 1.9.3)
+        // barnard_exact([[7, 12], [8, 3]], pooled=False, alternative='greater')
+        //
+        // R: 3.6.1; Exact 3.2.0
+        // require('Exact')
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='z-unpooled', alternative='g', npNumbers=33)[c(1,3)]
+
+        // The implementation more closely matches SciPy than R for the z value; the p-value
+        // is dependent on the z computation and also the sum to find the nuisance parameter.
+        // This particularly effects the test without optimization using R as the reference.
+
+        final Stream.Builder<Arguments> builder = Stream.builder();
+        // SciPy
+        builder.add(Arguments.of(7, 12, 8, 3,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {-2.018932132718121},
+            new double[] {0.06815343273153582, 1, 0.034076716365767874}, 1e-15, 7e-15));
+        // R without optimization
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='z-unpooled', alternative='t', npNumbers=15, ref.pvalue=FALSE)[c(1,3)]
+        builder.add(Arguments.of(7, 12, 8, 3,
+            Method.Z_UNPOOLED, 15, false,
+            new double[] {-2.0189321327199998},
+            new double[] {0.067726937136699999, 1, 0.033863468568400001}, 1e-12, 3e-3));
+
+        builder.add(Arguments.of(8, 2, 1, 5,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {3.011042066675127},
+            new double[] {0.02511596679687499, 0.012721998585868003, 1}, 1e-15, 3e-15));
+
+        // SciPy example for Boschloo's test
+        builder.add(Arguments.of(74, 31, 43, 32,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {1.8197405688188515},
+            // R:         0.087944196092599999, 0.076136257998199994, 1
+            new double[] {0.087944212768358360, 0.07613626462554106, 1}, 1e-15, 2e-13));
+
+        // Larger tables.
+        builder.add(Arguments.of(123, 92, 424, 113,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {-5.733263012126067},
+            new double[] {7.1612401340371655e-06, 1, 7.1612401184869755e-06}, 1e-15, 1e-12));
+
+        builder.add(Arguments.of(123, 92, 424, 313,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {-0.0837781159838051},
+            // R:         1                 , 1, 0.47180327976999997 (33 points)
+            //                                   0.47653831055000001 (100 points)
+            new double[] {0.9480782554147217, 1, 0.4765383214549828}, 1e-15, 1e-12));
+        builder.add(Arguments.of(67, 42, 23, 88,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {6.838950390748158},
+            // R:         8.7815106038399997e-10, 8.6790731909900004e-10 (33 points)
+            new double[] {8.7815108621324530e-10, 8.679073193094083e-10, 1}, 1e-15, 1e-13));
+
+        // Edge case: p0 == p1
+        // SciPy allows the nuisance parameter to be zero so computes p = 1.0
+        // R Exact does not and computes p = 0.99986000910299999
+        // To pass the non-exact assertion with 1.0 we use nextDown
+        builder.add(Arguments.of(7, 12, 7, 12,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {0},
+            new double[] {1, Math.nextDown(1.0), Math.nextDown(1.0)}, 1e-15, 3e-7));
+
+        // Edge case minimum tables.
+        builder.add(Arguments.of(1, 0, 0, 1,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {Double.POSITIVE_INFINITY},
+            new double[] {0.5, 0.25, 1}, 1e-15, 1e-15));
+        builder.add(Arguments.of(0, 1, 1, 0,
+            Method.Z_UNPOOLED, 33, true,
+            new double[] {Double.NEGATIVE_INFINITY},
+            new double[] {0.5, 1, 0.25}, 1e-15, 1e-15));
+        return builder.build();
+    }
+
+    static Stream<Arguments> testBoschloo() {
+        // p-values are in the AlternativeHypothesis enum order: two-sided, greater, less
+        // statistic is in the same order; or an array of length 1 if the statistic is the
+        // same.
+
+        // Reference data:
+        //
+        // scipy.stats.boschloo_exact (version 1.9.3)
+        // barnard_exact([[7, 12], [8, 3]], pooled=False, alternative='greater')
+        // Note: Only for 'less' or 'greater'. The 'two-sided' alternative uses double the
+        // lowest one-sided result.
+        //
+        // R: 3.6.1; Exact 3.2.0
+        // require('Exact')
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='boschloo', alternative='g', npNumbers=33)[c(1,3)]
+        // This uses tsmethod='square' by default for the two-sided alternative using the two-sided
+        // Fisher p-value. The method 'central' matches the SciPy implementation by doubling the
+        // one-sided result.
+
+        // The p-value is dependent on the library implementation of the hypergeometric distribution.
+        // Note that SciPy does not use p <= p0. It uses p <= p0*(1+1e-13) to allow some floating
+        // point error when comparing the Fisher p-value's. See https://github.com/scipy/scipy/pull/14178
+        // This has not been implemented in the Java code which uses an exact inequality.
+        //
+        // The following reference data uses R for the two-sided test statistic as this is not
+        // supported by SciPy. The two-sided p-value can use the SciPy result if it closely matches
+        // the R result (i.e. doubling the one-sided test is valid); the SciPy result is provided
+        // below as BoschlooExactResult showing that the statistic can be different and the p-value
+        // is often not within 2 significant figures.
+        //
+        // SciPy is used for the one-sided tests (as the values are closer to the Java implementation).
+        // The relative epsilon values are typically limited by the R implementation.
+        //
+        // Note that the statistic is also checked for an exact match against the
+        // FisherExactTest p-value to verify the two implementations are consistent.
+
+        final Stream.Builder<Arguments> builder = Stream.builder();
+        // BoschlooExactResult(statistic=0.06406796601699151, pvalue=0.06821830932319489)
+        builder.add(Arguments.of(7, 12, 8, 3,
+            Method.BOSCHLOO, 33, true,
+            new double[] {0.12813593203400001, 0.9895302348825588, 0.06406796601699151},
+            new double[] {0.06821830932319489, 0.9771215347573191, 0.034109154661597446}, 2e-13, 7e-15));
+        // R without optimization
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='boschloo', alternative='t', npNumbers=15, ref.pvalue=FALSE)[c(1,3)]
+        builder.add(Arguments.of(7, 12, 8, 3,
+            Method.BOSCHLOO, 15, false,
+            new double[] {0.12813593203400001, 0.98953023488299996, 0.064067966017000003},
+            new double[] {0.067726937136699999, 0.97712153475700003, 0.033863468568400001}, 5e-13, 2e-12));
+
+        // BoschlooExactResult(statistic=0.024475524475524483, pvalue=0.024384872263939393)
+        builder.add(Arguments.of(8, 2, 1, 5,
+            Method.BOSCHLOO, 33, true,
+            new double[] {0.034965034965000003, 0.024475524475524483, 0.9991258741258742},
+            new double[] {0.019304891712500001, 0.012192436131969697, 0.9870565910170339}, 1e-12, 4e-10));
+
+        // SciPy example for Boschloo's test
+        // BoschlooExactResult(statistic=0.048312210086912236, pvalue=0.0711281286030935)
+        builder.add(Arguments.of(74, 31, 43, 32,
+            Method.BOSCHLOO, 33, true,
+            new double[] {0.081794674954999994, 0.048312210086912236, 0.9759961281714722},
+            new double[] {0.072078751323299994, 0.03556406430154675, 0.9665032229005569}, 2e-14, 3e-10));
+
+        // Larger tables.
+        // SciPy is slow here. It is fast for barnard_exact which shares the p-value optimization
+        // code so the slow speed may be in the selection of the more extreme tables using the
+        // hypergeom implementation.
+
+        // BoschlooExactResult(statistic=2.826445350300923e-09, pvalue=3.618688125749579e-09)
+        builder.add(Arguments.of(123, 92, 424, 113,
+            Method.BOSCHLOO, 33, true,
+            new double[] {4.4347446136499998e-09, 0.9999999990211362, 2.826445350300923e-09},
+            new double[] {3.6182638424499998e-09, 0.9999999983112282, 1.8093440628747895e-09}, 6e-13, 7e-8));
+        // BoschlooExactResult(statistic=0.4969777824620944, pvalue=0.9428559669698119)
+        // Here the p-value function for greater/less is flat with many local minima.
+        // SciPy does better for the 'less' function.
+        // R does better for the 'greater' function.
+        // Using 33 points matches SciPy for greater. This must be increased to 50 points for
+        // less where we can match the higher result from R.
+        // Note the true maxima for 'less' is located between two points (when sampled with 33
+        // points) that are not local maxima. Thus the optimization must increase the number
+        // of points to identify better start candidates, or use an optimization routine that
+        // detects the flat function and optimizes over a broad range.
+        builder.add(Arguments.of(123, 92, 424, 313,
+            Method.BOSCHLOO, 50, true,
+            new double[] {0.93767135630200005, 0.5652358165696375, 0.4969777824620944},
+            // R:                              0.53928064412099996,0.47134187918800002 (33 points)
+            //                                 0.53935860353700005,0.47142798346100001 (60 points)
+            //                                 0.53935860234499999,0.47142798338899999 (100 point - worse than with 60 points)
+            // SciPy:                          0.5392806447420694, 0.47142798348490594 (32 points)
+            //                                 0.539358603564275,  0.4714279834851383  (128 points)
+            new double[] {0.93370280995499999, 0.53935860353700005, 0.47142798348490594}, 2e-13, 5e-9));
+        // BoschlooExactResult(statistic=5.169903676658518e-10, pvalue=5.215196886364725e-10)
+        builder.add(Arguments.of(67, 42, 23, 88,
+            Method.BOSCHLOO, 33, true,
+            new double[] {8.7327872452500003e-10, 5.169903676658518e-10, 0.9999999999188225},
+            new double[] {5.6543598496900003e-10, 2.6075984431823626e-10, 0.999999999768292}, 3e-13, 1e-9));
+
+        // Edge case: p0 == p1
+        builder.add(Arguments.of(7, 12, 7, 12,
+            Method.BOSCHLOO, 33, true,
+            new double[] {1, 0.6312858130655684, 0.6312858130655685},
+            new double[] {1, 0.5160595470655773, 0.5160595470655791}, 1e-15, 1e-14));
+
+        // Edge case minimum tables.
+        builder.add(Arguments.of(1, 0, 0, 1,
+            Method.BOSCHLOO, 33, true,
+            new double[] {1, 0.5, 1},
+            new double[] {1, 0.25, 1}, 1e-15, 1e-15));
+        builder.add(Arguments.of(0, 1, 1, 0,
+            Method.BOSCHLOO, 33, true,
+            new double[] {1, 1, 0.5},
+            new double[] {1, 1, 0.25}, 1e-15, 1e-15));
+        return builder.build();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testNuisanceParameter(int a, int b, int c, int d,
+        AlternativeHypothesis alternative, Method method, int points, boolean optimize,
+        double[] expected, double[] eps) {
+        final int[][] table = {{a, b}, {c, d}};
+        final UnconditionedExactTest test = UnconditionedExactTest.withDefaults()
+            .with(alternative).with(method).withInitialPoints(points).withOptimize(optimize);
+        double statistic = test.statistic(table);
+        TestUtils.assertRelativelyEquals(expected[0], statistic, eps[0], "statistic");
+        final Result r = test.test(table);
+        Assertions.assertEquals(statistic, r.getStatistic(), "statistic mismatch");
+        TestUtils.assertProbability(expected[1], r.getPValue(), eps[1], "p-value");
+        TestUtils.assertRelativelyEquals(expected[2], r.getNuisanceParameter(), eps[2], "nuisance parameter");
+    }
+
+    static Stream<Arguments> testNuisanceParameter() {
+        // expected values are in the order: statistic, p-value, nuisance parameter with
+        // relative eps tolerance for each
+        final Stream.Builder<Arguments> builder = Stream.builder();
+        // Use the R implementation which provides a plot of the p-value verses the
+        // nuisance parameter to aid in data selection. Data requires no symmetry
+        // (i.e. no exact matching p-values) as the R implementation returns all maxima
+        // and the Java implementation only 1.
+        // The epsilons are relatively low as often the Java implementation finds a
+        // better p-value, even with fewer initial points.
+
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='z-unpooled', alternative='t', npNumbers=33, ref.pvalue=FALSE)[c(1, 3, 8)]
+        builder.add(Arguments.of(7, 12, 8, 4,
+            AlternativeHypothesis.LESS_THAN, Method.Z_UNPOOLED, 33, false,
+            new double[] {-1.68390442589, 0.066796091742499994, 0.65624687500000001},
+            new double[] {1e-12, 1e-10, 1e-10}));
+        // exact.test(matrix(c(7, 12, 8, 3), 2, 2), method='z-unpooled', alternative='t', npNumbers=33, ref.pvalue=TRUE)[c(1, 3, 8)]
+        builder.add(Arguments.of(7, 12, 8, 4,
+            AlternativeHypothesis.LESS_THAN, Method.Z_UNPOOLED, 33, true,
+            new double[] {-1.68390442589, 0.066810461623799999, 0.65134101325505922},
+            new double[] {1e-12, 1e-10, 3e-6}));
+
+        // Generated with npNumbers=100 but use the default of 33 for the Java implementation
+        builder.add(Arguments.of(7, 12, 8, 7,
+            AlternativeHypothesis.LESS_THAN, Method.Z_POOLED, 33, true,
+            new double[] {-0.96159557564099996, 0.21902132934499999, 0.95694046624745288},
+            new double[] {1e-12, 5e-8, 2e-5}));
+        builder.add(Arguments.of(7, 8, 8, 6,
+            AlternativeHypothesis.LESS_THAN, Method.Z_POOLED, 33, true,
+            new double[] {-0.564160122652, 0.34711165127799998, 0.11654765288429031},
+            new double[] {1e-12, 5e-8, 2e-4}));
+
+        return builder.build();
+    }
+}

--- a/src/conf/checkstyle/checkstyle-suppressions.xml
+++ b/src/conf/checkstyle/checkstyle-suppressions.xml
@@ -36,5 +36,6 @@
   <suppress checks="ParameterNumber" files=".*[/\\]KolmogorovSmirnovTestTest.java" />
   <suppress checks="ParameterNumber" files=".*[/\\]MannWhitneyUTestTest.java" />
   <suppress checks="ParameterNumber" files=".*[/\\]WilcoxonSignedRankTestTest.java" />
+  <suppress checks="ParameterNumber" files=".*[/\\]UnconditionedExactTestTest.java" />
   <suppress checks="MethodLength" files=".*[/\\]WilcoxonSignedRankTestTest.java" />
 </suppressions>

--- a/src/conf/pmd/pmd-ruleset.xml
+++ b/src/conf/pmd/pmd-ruleset.xml
@@ -114,7 +114,7 @@
       <property name="violationSuppressXPath"
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='AbstractContinuousDistribution'
           or @SimpleName='KolmogorovSmirnovTest' or @SimpleName='KolmogorovSmirnovDistribution'
-          or @SimpleName='MannWhitneyUTest']"/>
+          or @SimpleName='MannWhitneyUTest' or @SimpleName='BrentOptimizer']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/CyclomaticComplexity">
@@ -123,7 +123,7 @@
       <property name="methodReportLevel" value="20"/>
       <property name="violationSuppressXPath"
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='KolmogorovSmirnovTest'
-            or @SimpleName='DD']"/>
+            or @SimpleName='DD' or @SimpleName='BrentOptimizer']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts">
@@ -137,18 +137,19 @@
       <!-- Method length is due to comments. -->
       <property name="violationSuppressXPath"
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='AbstractContinuousDistribution'
-          or @SimpleName='KolmogorovSmirnovTest' or @SimpleName='KolmogorovSmirnovDistribution' or @SimpleName='DD']"/>
+          or @SimpleName='KolmogorovSmirnovTest' or @SimpleName='KolmogorovSmirnovDistribution' or @SimpleName='DD'
+          or @SimpleName='BracketFinder' or @SimpleName='BrentOptimizer']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/CognitiveComplexity">
     <properties>
       <!-- Methods AbstractContinuousDistribution inverseProbability (21) and
-        searchPlateau (26) exceed threshold of 15.
-        Individual method names are from KolmogorovSmirnovTest. -->
+        searchPlateau (26) exceed threshold of 15. -->
       <property name="violationSuppressXPath"
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='AbstractContinuousDistribution'
           or @SimpleName='KolmogorovSmirnovTest' or @SimpleName='KolmogorovSmirnovDistribution'
-          or @SimpleName='MannWhitneyUTest']"/>
+          or @SimpleName='MannWhitneyUTest' or @SimpleName='BracketFinder'
+          or @SimpleName='BrentOptimizer' or @SimpleName='UnconditionedExactTest']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/GodClass">
@@ -158,7 +159,7 @@
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='NaturalRanking'
           or @SimpleName='KolmogorovSmirnovTest' or @SimpleName='DD' or @SimpleName='Arguments'
           or @SimpleName='MannWhitneyUTest' or @SimpleName='WilcoxonSignedRankTest'
-          or @SimpleName='HypergeometricDistribution']"/>
+          or @SimpleName='HypergeometricDistribution' or @SimpleName='UnconditionedExactTest']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/LogicInversion">
@@ -172,7 +173,8 @@
     <properties>
       <property name="violationSuppressXPath"
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='KolmogorovSmirnovTest'
-          or @SimpleName='KolmogorovSmirnovDistribution' or @SimpleName='DD']"/>
+          or @SimpleName='KolmogorovSmirnovDistribution' or @SimpleName='DD'
+          or @SimpleName='UnconditionedExactTest']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/UselessOverridingMethod">
@@ -197,13 +199,13 @@
         DD methods are hi() and lo() for the two parts of the double-double number. -->
       <property name="violationSuppressXPath"
         value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='IntList'
-          or @SimpleName='DD']"/>
+          or @SimpleName='DD' or @SimpleName='XYList' ]"/>
     </properties>
   </rule>
   <rule ref="category/java/errorprone.xml/TestClassWithoutTestCases">
     <properties>
       <property name="violationSuppressRegex"
-        value=".*'BinomialTest'.*|.*'ChiSquareTest'.*|.*'FisherExactTest'.*|.*'GTest'.*|.*'KolmogorovSmirnovTest'.*|.*'MannWhitneyUTest'.*|.*'TTest'.*|.*'WilcoxonSignedRankTest'.*"/>
+        value=".*'BinomialTest'.*|.*'ChiSquareTest'.*|.*'FisherExactTest'.*|.*'GTest'.*|.*'KolmogorovSmirnovTest'.*|.*'MannWhitneyUTest'.*|.*'TTest'.*|.*'WilcoxonSignedRankTest'.*|.*'UnconditionedExactTest'.*"/>
     </properties>
   </rule>
 
@@ -216,9 +218,11 @@
   </rule>
   <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops">
     <properties>
-      <!-- The resized array f is created inside a loop -->
+      <!-- MannWhitneyUTest: The resized array f is created inside a loop.
+        UnconditionedExactTest: Creates a distribution in outer loop to control an inner loop.  -->
       <property name="violationSuppressXPath"
-        value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='MannWhitneyUTest']"/>
+        value="./ancestor-or-self::ClassOrInterfaceDeclaration[@SimpleName='MannWhitneyUTest'
+          or @SimpleName='UnconditionedExactTest']"/>
     </properties>
   </rule>
 

--- a/src/conf/spotbugs/spotbugs-exclude-filter.xml
+++ b/src/conf/spotbugs/spotbugs-exclude-filter.xml
@@ -66,10 +66,29 @@
     <Method name="getMidPoint" />
     <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
   </Match>
+  <!-- Same logic as above distribution is used in the internal helper class constructor -->
+  <Match>
+    <Class name="org.apache.commons.statistics.inference.Hypergeom" />
+    <Method name="&lt;init&gt;" />
+    <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
+  </Match>
 
   <Match>
     <Class name="org.apache.commons.statistics.ranking.NaturalRanking$DataPosition" />
     <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS" />
+  </Match>
+
+  <!-- False positive of static method returning an immutable instance -->
+  <Match>
+    <Class name="org.apache.commons.statistics.inference.UnconditionedExactTest" />
+    <Bug pattern="MS_EXPOSE_REP" />
+  </Match>
+
+  <!-- False positive -->
+  <Match>
+    <Class name="org.apache.commons.statistics.inference.UnconditionedExactTest" />
+    <Method name="computePValue" />
+    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
   </Match>
 
 </FindBugsFilter>


### PR DESCRIPTION
Support computing a test conditioned on the column sums using a configurable method to identify more extreme tables. The p-value is computed by maximising the probability over the more extreme tables.

The Commons Math BrentOptimizer has been extracted for use as a univariate function optimizer. This has been modified to remove unused functionality and support bounds on the function.
